### PR TITLE
Add IETF side meetings to Sessions and Schedule

### DIFF
--- a/app/src/main/java/org/ietf/ietfsched/io/LocalExecutor.java
+++ b/app/src/main/java/org/ietf/ietfsched/io/LocalExecutor.java
@@ -76,6 +76,13 @@ public class LocalExecutor {
 	}
 
 	public void execute(JSONObject stream, int meetingNumber) throws Exception {
+		execute(stream, meetingNumber, null);
+	}
+
+	/**
+	 * Import agenda JSON, optionally merging side-meeting ops into the same sync batch/purge.
+	 */
+	public void execute(JSONObject stream, int meetingNumber, JSONObject sideMeetingsData) throws Exception {
 		if (stream != null) {
 			// Set the meeting number for Meeting objects to use when building URLs
 			Meeting.setMeetingNumber(meetingNumber);
@@ -84,17 +91,21 @@ public class LocalExecutor {
 			if (meetings.size() == 0) {
 				throw new IOException("Cannot decode inputStream. Not an agenda ? ");
 			}
-			executeBuild(meetings);
+			executeBuild(meetings, meetingNumber, sideMeetingsData);
 		}
 		else {
 			throw new IOException("Invalid inputStream."); 
 		}
 	}
 
-	private void executeBuild(ArrayList<Meeting> meetings) {
+	private void executeBuild(ArrayList<Meeting> meetings, int meetingNumber, JSONObject sideMeetingsData) {
 		final long versionBuild = System.currentTimeMillis();
 		try {
 			ArrayList<ContentProviderOperation> batch = transform(meetings, versionBuild);
+			if (sideMeetingsData != null) {
+				batch.addAll(SideMeetingImporter.buildOperations(
+						sideMeetingsData, meetingNumber, versionBuild, mResolver));
+			}
 			mResolver.applyBatch(mAuthority, batch);
 			ArrayList<ContentProviderOperation> batchClean = purge(versionBuild);
 			mResolver.applyBatch(mAuthority, batchClean);
@@ -115,6 +126,10 @@ public class LocalExecutor {
 		final ArrayList<ContentProviderOperation> batch = Lists.newArrayList();
 		for (int i = 0; i < meetings.size(); i++) {
 			Meeting m = meetings.get(i);
+			// Registration is low-value clutter; omit entirely.
+			if (isRegistration(m)) {
+				continue;
+			}
 			ContentProviderOperation cp = createBlock(m, versionBuild); 
 			if (cp != null) {
 				batch.add(cp);
@@ -139,6 +154,11 @@ public class LocalExecutor {
 			}
 		}
 		return batch;
+	}
+
+	private static boolean isRegistration(Meeting m) {
+		String titleLower = m.title.toLowerCase(Locale.ROOT);
+		return m.typeSession.contains("Registration") || titleLower.contains("registration");
 	}
 	
 	private ContentProviderOperation createBlock(Meeting m, long versionBuild) throws Exception {
@@ -181,9 +201,9 @@ public class LocalExecutor {
 		}
 		else if (titleLower.contains("hackathon")){
 			title = m.title;
-			// Hackathon Results Presentations go in green column to avoid overlap with main Hackathon
+			// Hackathon Results Presentations → yellow (former green) to avoid overlap with main Hackathon
 			if (titleLower.contains("results") || titleLower.contains("presentations")) {
-				blockType = ParserUtils.BLOCK_TYPE_OFFICE_HOURS;
+				blockType = ParserUtils.BLOCK_TYPE_NOC_HELPDESK;
 			} else {
 				blockType = ParserUtils.BLOCK_TYPE_HACKATHON;
 			}
@@ -201,20 +221,12 @@ public class LocalExecutor {
 			boolean isStaffOfficeHours = isStaffGroup || containsAny(titleLower, "coordinator", "liaison");
 			
 			if (isStaffOfficeHours) {
-				// Map AD office hours to NOC column (yellow) to reduce overlap with other green blocks
-				if (titleLower.contains("ad office hours")) {
-					blockType = ParserUtils.BLOCK_TYPE_NOC_HELPDESK;
-				} else {
-					blockType = ParserUtils.BLOCK_TYPE_OFFICE_HOURS;
-				}
+				// All staff/AD office hours → yellow (green reserved for side meetings)
+				blockType = ParserUtils.BLOCK_TYPE_NOC_HELPDESK;
 				title = m.title;
 			}
 		}
-		// Check typeSession patterns
-		else if (m.typeSession.contains("Registration") || titleLower.contains("registration")) {
-			title = ParserUtils.BLOCK_TITLE_REGISTRATION;
-			blockType = ParserUtils.BLOCK_TYPE_OFFICE_HOURS;
-		}
+		// Registration handled by isRegistration() skip in transform()
 		else if (m.typeSession.contains("None")) {
 			title = "...";
 			blockType = ParserUtils.BLOCK_TYPE_SESSION;
@@ -240,13 +252,13 @@ public class LocalExecutor {
 					"happy hour", "game night", "networking")) {
 				blockType = ParserUtils.BLOCK_TYPE_FOOD;
 			} 
-			// Administrative/educational/special programs → Green
+			// Administrative/educational/special programs → yellow (green = side meetings)
 			else if (containsAny(titleLower, "education", "outreach", "tutorial", "newcomer", 
 					"new participant", "tools", "chairs", "forum", "program", "series", "sprint", 
 					"hotrfc", "lightning talk", "office hours")) {
-				blockType = ParserUtils.BLOCK_TYPE_OFFICE_HOURS;
+				blockType = ParserUtils.BLOCK_TYPE_NOC_HELPDESK;
 			} 
-			// Other special sessions (evening WG sessions, side meetings) → keep as Red
+			// Other special sessions (evening WG sessions) → keep as Red
 			else {
 				blockType = ParserUtils.BLOCK_TYPE_SESSION;
 			}

--- a/app/src/main/java/org/ietf/ietfsched/io/RemoteExecutor.java
+++ b/app/src/main/java/org/ietf/ietfsched/io/RemoteExecutor.java
@@ -117,11 +117,26 @@ public class RemoteExecutor {
 
 	// Get a JSON object from a remote server.
 	public JSONObject executeJSONGet(String urlString) throws Exception {
+		return executeJSONGet(urlString, 0, 0);
+	}
+
+	/**
+	 * GET JSON with optional connect/read timeouts (milliseconds).
+	 * Pass 0 for a timeout to keep the platform default.
+	 */
+	public JSONObject executeJSONGet(String urlString, int connectTimeoutMs, int readTimeoutMs)
+			throws Exception {
 		URL url;
 		HttpURLConnection urlConnection = null;
 		try {
 			url = new URI(urlString).toURL();
 			urlConnection = (HttpsURLConnection) url.openConnection();
+			if (connectTimeoutMs > 0) {
+				urlConnection.setConnectTimeout(connectTimeoutMs);
+			}
+			if (readTimeoutMs > 0) {
+				urlConnection.setReadTimeout(readTimeoutMs);
+			}
 
 			int status = urlConnection.getResponseCode();
 			if (status == HttpsURLConnection.HTTP_OK) {

--- a/app/src/main/java/org/ietf/ietfsched/io/SideMeetingImporter.java
+++ b/app/src/main/java/org/ietf/ietfsched/io/SideMeetingImporter.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ietf.ietfsched.io;
+
+import android.content.ContentProviderOperation;
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.text.TextUtils;
+import android.util.Log;
+
+import org.ietf.ietfsched.provider.ScheduleContract.Blocks;
+import org.ietf.ietfsched.provider.ScheduleContract.Rooms;
+import org.ietf.ietfsched.provider.ScheduleContract.Sessions;
+import org.ietf.ietfsched.util.Lists;
+import org.ietf.ietfsched.util.ParserUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+
+/**
+ * Imports informal side-meeting bookings from https://sidemeetings.ietf.org/_data
+ * into the same blocks/rooms/sessions tables used by the agenda sync.
+ */
+public class SideMeetingImporter {
+    private static final String TAG = "SideMeetingImporter";
+    public static final String SIDE_MEETINGS_URL = "https://sidemeetings.ietf.org/_data";
+    /** Short timeouts so a broken informal API never stalls agenda sync. */
+    public static final int CONNECT_TIMEOUT_MS = 4000;
+    public static final int READ_TIMEOUT_MS = 6000;
+
+    private SideMeetingImporter() {}
+
+    /**
+     * Build insert ops for side meetings. Returns empty list on any problem.
+     * Caller must use the same {@code versionBuild} as the agenda batch so purge keeps both.
+     */
+    public static ArrayList<ContentProviderOperation> buildOperations(
+            JSONObject sideData, int expectedMeetingNumber, long versionBuild,
+            ContentResolver resolver) {
+        ArrayList<ContentProviderOperation> batch = Lists.newArrayList();
+        if (sideData == null || sideData.length() == 0) {
+            return batch;
+        }
+        try {
+            JSONObject meeting = sideData.optJSONObject("meeting");
+            if (meeting == null) {
+                Log.w(TAG, "No meeting object in side meetings data");
+                return batch;
+            }
+            String numberStr = meeting.optString("meetingNumber", "");
+            int sideMeetingNumber;
+            try {
+                sideMeetingNumber = Integer.parseInt(numberStr.trim());
+            } catch (NumberFormatException e) {
+                Log.w(TAG, "Invalid side meeting number: " + numberStr);
+                return batch;
+            }
+            if (sideMeetingNumber != expectedMeetingNumber) {
+                Log.i(TAG, "Skipping side meetings: data is for IETF " + sideMeetingNumber
+                        + " but app meeting is " + expectedMeetingNumber);
+                return batch;
+            }
+
+            HashMap<Long, Integer> roomSubColumn = assignRoomSubColumns(sideData.optJSONArray("rooms"));
+            JSONArray bookings = sideData.optJSONArray("bookings");
+            if (bookings == null || bookings.length() == 0) {
+                Log.i(TAG, "No side meeting bookings");
+                return batch;
+            }
+
+            for (int i = 0; i < bookings.length(); i++) {
+                JSONObject booking = bookings.optJSONObject(i);
+                if (booking == null) continue;
+                ContentProviderOperation[] ops = buildBookingOps(booking, roomSubColumn, versionBuild, resolver);
+                if (ops != null) {
+                    Collections.addAll(batch, ops);
+                }
+            }
+            Log.i(TAG, "Prepared " + batch.size() + " ops for " + bookings.length() + " side bookings");
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to parse side meetings data", e);
+            batch.clear();
+        }
+        return batch;
+    }
+
+    private static HashMap<Long, Integer> assignRoomSubColumns(JSONArray rooms) {
+        HashMap<Long, Integer> map = new HashMap<>();
+        if (rooms == null || rooms.length() == 0) {
+            return map;
+        }
+        ArrayList<JSONObject> sorted = new ArrayList<>();
+        for (int i = 0; i < rooms.length(); i++) {
+            JSONObject room = rooms.optJSONObject(i);
+            if (room != null) sorted.add(room);
+        }
+        Collections.sort(sorted, new Comparator<JSONObject>() {
+            @Override
+            public int compare(JSONObject a, JSONObject b) {
+                String ta = a.optString("title", a.optString("slug", ""));
+                String tb = b.optString("title", b.optString("slug", ""));
+                return ta.compareToIgnoreCase(tb);
+            }
+        });
+        for (int i = 0; i < sorted.size(); i++) {
+            long id = sorted.get(i).optLong("id", -1);
+            if (id >= 0) {
+                map.put(id, Math.min(i, 1)); // at most two parallel rooms
+            }
+        }
+        return map;
+    }
+
+    private static ContentProviderOperation[] buildBookingOps(
+            JSONObject booking, HashMap<Long, Integer> roomSubColumn,
+            long versionBuild, ContentResolver resolver) {
+        try {
+            long bookingId = booking.optLong("id", -1);
+            if (bookingId < 0) return null;
+
+            String title = booking.optString("title", "").trim();
+            if (title.isEmpty()) return null;
+
+            String startIso = booking.optString("start", "");
+            String endIso = booking.optString("end", "");
+            long startMillis = parseIsoMillis(startIso);
+            long endMillis = parseIsoMillis(endIso);
+            if (startMillis <= 0 || endMillis <= startMillis) {
+                Log.w(TAG, "Bad times for booking " + bookingId);
+                return null;
+            }
+
+            String roomName = booking.optString("roomName", "").trim();
+            long roomApiId = booking.optLong("roomId", -1);
+            int sub = roomSubColumn.containsKey(roomApiId) ? roomSubColumn.get(roomApiId) : 0;
+            String blockType = ParserUtils.BLOCK_TYPE_SIDE_MEETING + sub;
+
+            String sessionKey = "side-" + bookingId;
+            String sessionId = Sessions.generateSessionId(sessionKey);
+            // Unique block per booking (1:1) so parallel same-slot rooms do not collide.
+            String blockId = sessionId;
+            String roomId = roomName.isEmpty() ? null : Rooms.generateRoomId(roomName);
+
+            String joinUrl = booking.optString("location", "").trim();
+            String description = booking.optString("description", "").trim();
+            String organizer = booking.optString("organizerName", "").trim();
+            String organizerEmail = booking.optString("organizerEmail", "").trim();
+            String areas = joinAreas(booking.optJSONArray("areas"));
+
+            StringBuilder abstractText = new StringBuilder();
+            if (!organizer.isEmpty()) {
+                abstractText.append("Organizer: ").append(organizer);
+                if (!organizerEmail.isEmpty()) {
+                    abstractText.append(" <").append(organizerEmail).append(">");
+                }
+                abstractText.append("\n\n");
+            }
+            if (!areas.isEmpty()) {
+                abstractText.append("Areas: ").append(areas).append("\n\n");
+            }
+            abstractText.append(description);
+
+            ArrayList<ContentProviderOperation> ops = new ArrayList<>();
+
+            if (roomId != null) {
+                ops.add(ContentProviderOperation.newInsert(Rooms.CONTENT_URI)
+                        .withValue(Rooms.ROOM_ID, roomId)
+                        .withValue(Rooms.ROOM_NAME, roomName)
+                        .withValue(Rooms.ROOM_FLOOR, " ")
+                        .build());
+            }
+
+            ops.add(ContentProviderOperation.newInsert(Blocks.CONTENT_URI)
+                    .withValue(Blocks.UPDATED, versionBuild)
+                    .withValue(Blocks.BLOCK_ID, blockId)
+                    .withValue(Blocks.BLOCK_TITLE, title)
+                    .withValue(Blocks.BLOCK_START, startMillis)
+                    .withValue(Blocks.BLOCK_END, endMillis)
+                    .withValue(Blocks.BLOCK_TYPE, blockType)
+                    .build());
+
+            ContentProviderOperation.Builder session = ContentProviderOperation.newInsert(Sessions.CONTENT_URI)
+                    .withValue(Sessions.UPDATED, versionBuild)
+                    .withValue(Sessions.SESSION_ID, sessionId)
+                    .withValue(Sessions.SESSION_TITLE, title)
+                    .withValue(Sessions.SESSION_ABSTRACT, abstractText.toString().trim())
+                    .withValue(Sessions.SESSION_URL, joinUrl)
+                    .withValue(Sessions.SESSION_KEYWORDS, areas)
+                    .withValue(Sessions.SESSION_REQUIREMENTS, null)
+                    .withValue(Sessions.BLOCK_ID, blockId)
+                    .withValue(Sessions.ROOM_ID, roomId)
+                    .withValue(Sessions.SESSION_PDF_URL, null)
+                    .withValue(Sessions.SESSION_DRAFTS_URL, null)
+                    .withValue(Sessions.SESSION_RES_URI, null)
+                    .withValue(Sessions.SESSION_IS_BOF, 0);
+
+            final Uri sessionUri = Sessions.buildSessionUri(sessionId);
+            final int starred = querySessionStarred(sessionUri, resolver);
+            if (starred != -1) {
+                session.withValue(Sessions.SESSION_STARRED, starred);
+            }
+            ops.add(session.build());
+
+            return ops.toArray(new ContentProviderOperation[0]);
+        } catch (Exception e) {
+            Log.w(TAG, "Skipping booking", e);
+            return null;
+        }
+    }
+
+    private static String joinAreas(JSONArray areas) {
+        if (areas == null || areas.length() == 0) return "";
+        ArrayList<String> parts = new ArrayList<>();
+        for (int i = 0; i < areas.length(); i++) {
+            String a = areas.optString(i, "").trim();
+            if (!a.isEmpty()) parts.add(a);
+        }
+        return TextUtils.join(", ", parts);
+    }
+
+    private static long parseIsoMillis(String iso) {
+        if (iso == null || iso.isEmpty()) return 0;
+        try {
+            return Instant.parse(iso).toEpochMilli();
+        } catch (Exception e) {
+            // Fallback: strip fractional seconds
+            try {
+                String cleaned = iso.replaceAll("\\.\\d+", "");
+                return Instant.parse(cleaned).toEpochMilli();
+            } catch (Exception e2) {
+                Log.w(TAG, "Cannot parse ISO time: " + iso);
+                return 0;
+            }
+        }
+    }
+
+    private static int querySessionStarred(Uri uri, ContentResolver resolver) {
+        Cursor cursor = resolver.query(uri, new String[]{Sessions.SESSION_STARRED}, null, null, null);
+        int starred = -1;
+        if (cursor != null) {
+            try {
+                if (cursor.moveToFirst()) {
+                    starred = cursor.getInt(0);
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+        return starred;
+    }
+}

--- a/app/src/main/java/org/ietf/ietfsched/service/SyncService.java
+++ b/app/src/main/java/org/ietf/ietfsched/service/SyncService.java
@@ -21,6 +21,7 @@ import org.ietf.ietfsched.io.LocalExecutor;
 import org.ietf.ietfsched.io.MeetingDetector;
 import org.ietf.ietfsched.io.MeetingMetadata;
 import org.ietf.ietfsched.io.RemoteExecutor;
+import org.ietf.ietfsched.io.SideMeetingImporter;
 import org.ietf.ietfsched.provider.ScheduleProvider;
 import org.ietf.ietfsched.util.MeetingPreferences;
 import org.ietf.ietfsched.util.ParserUtils;
@@ -64,7 +65,7 @@ public class SyncService extends IntentService {
 
     private static final String noteWellURL = "https://www.ietf.org/media/documents/note-well.md";
 	private static final int VERSION_NONE = 0;
-    private static final int VERSION_CURRENT = 47;
+    private static final int VERSION_CURRENT = 48;
 
     private LocalExecutor mLocalExecutor;
     private RemoteExecutor mRemoteExecutor;
@@ -156,8 +157,24 @@ public class SyncService extends IntentService {
 			// Attempt to Collect the JSON content from the source.
 			JSONObject agenda = mRemoteExecutor.executeJSONGet(aUrl);
 			Log.d(TAG, String.format("remote sync started for URL: %s", aUrl));
-			// Parse the JSON data retrieved locally.
-			mLocalExecutor.execute(agenda, meeting.number);
+
+			// Soft-fetch side meetings (short timeout); never fail the agenda sync on this.
+			JSONObject sideMeetings = null;
+			try {
+				sideMeetings = mRemoteExecutor.executeJSONGet(
+						SideMeetingImporter.SIDE_MEETINGS_URL,
+						SideMeetingImporter.CONNECT_TIMEOUT_MS,
+						SideMeetingImporter.READ_TIMEOUT_MS);
+				if (sideMeetings == null || sideMeetings.length() == 0) {
+					Log.w(TAG, "Side meetings fetch returned empty data");
+					sideMeetings = null;
+				}
+			} catch (Exception sideErr) {
+				Log.w(TAG, "Side meetings fetch failed (continuing without them): " + sideErr.getMessage());
+				sideMeetings = null;
+			}
+
+			mLocalExecutor.execute(agenda, meeting.number, sideMeetings);
 			prefs.edit().putString(Prefs.LAST_ETAG, remoteEtag).apply();
 			prefs.edit().putInt(Prefs.LOCAL_VERSION, VERSION_CURRENT).apply();
 			Log.d(TAG, "remote sync finished");

--- a/app/src/main/java/org/ietf/ietfsched/ui/ScheduleFragment.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/ScheduleFragment.java
@@ -153,6 +153,10 @@ public class ScheduleFragment extends Fragment implements
         map.put(ParserUtils.BLOCK_TYPE_FOOD, 0);
         map.put(ParserUtils.BLOCK_TYPE_SESSION, 1);
         map.put(ParserUtils.BLOCK_TYPE_HACKATHON, 1);
+        map.put(ParserUtils.BLOCK_TYPE_SIDE_MEETING, 2);
+        map.put(ParserUtils.BLOCK_TYPE_SIDE_MEETING + "0", 2);
+        map.put(ParserUtils.BLOCK_TYPE_SIDE_MEETING + "1", 2);
+        // Legacy officehours (if any remain in DB) still render in green until next sync
         map.put(ParserUtils.BLOCK_TYPE_OFFICE_HOURS, 2);
         map.put(ParserUtils.BLOCK_TYPE_NOC_HELPDESK, 3);
         map.put(ParserUtils.BLOCK_TYPE_UNKNOWN, 99); // Unknown should not appear.
@@ -454,10 +458,14 @@ public class ScheduleFragment extends Fragment implements
         // Clear out any existing sessions before inserting again
         day.blocksView.removeAllBlocks();
 
+        final ArrayList<BlockView> sideBlocks = new ArrayList<>();
         try {
             while (cursor.moveToNext()) {
                 final String type = cursor.getString(BlocksQuery.BLOCK_TYPE);
-                final Integer column = sTypeColumnMap.get(type);
+                Integer column = sTypeColumnMap.get(type);
+                if (column == null && ParserUtils.isSideMeetingBlockType(type)) {
+                    column = 2;
+                }
                 
                 final String blockId = cursor.getString(BlocksQuery.BLOCK_ID);
                 final String title = cursor.getString(BlocksQuery.BLOCK_TITLE);
@@ -471,9 +479,10 @@ public class ScheduleFragment extends Fragment implements
                 final long start = cursor.getLong(BlocksQuery.BLOCK_START);
                 final long end = cursor.getLong(BlocksQuery.BLOCK_END);
                 final boolean containsStarred = cursor.getInt(BlocksQuery.CONTAINS_STARRED) != 0;
+                final int subColumn = ParserUtils.sideMeetingSubColumn(type);
 
                 final BlockView blockView = new BlockView(getActivity(), blockId, title, start, end,
-                        containsStarred, column);
+                        containsStarred, column, subColumn);
 
                 final int sessionsCount = cursor.getInt(BlocksQuery.SESSIONS_COUNT);
                 if (sessionsCount > 0) {
@@ -486,10 +495,28 @@ public class ScheduleFragment extends Fragment implements
                     buttonDrawable.getDrawable(2).setAlpha(DISABLED_BLOCK_ALPHA);
                 }
 
+                if (ParserUtils.isSideMeetingBlockType(type)) {
+                    sideBlocks.add(blockView);
+                }
                 day.blocksView.addBlock(blockView);
             }
         } finally {
             cursor.close();
+        }
+
+        // Side meetings: full green width when alone; half-width when time ranges overlap.
+        for (int i = 0; i < sideBlocks.size(); i++) {
+            BlockView a = sideBlocks.get(i);
+            boolean overlaps = false;
+            for (int j = 0; j < sideBlocks.size(); j++) {
+                if (i == j) continue;
+                BlockView b = sideBlocks.get(j);
+                if (a.getStartTime() < b.getEndTime() && b.getStartTime() < a.getEndTime()) {
+                    overlaps = true;
+                    break;
+                }
+            }
+            a.setHalfWidth(overlaps);
         }
     }
 
@@ -497,11 +524,17 @@ public class ScheduleFragment extends Fragment implements
     public void onClick(View view) {
         if (view instanceof BlockView) {
             final String blockId = ((BlockView) view).getBlockId();
-            final Uri sessionsUri = ScheduleContract.Blocks.buildSessionsUri(blockId);
-
-            final Intent intent = new Intent(Intent.ACTION_VIEW, sessionsUri);
-            intent.putExtra(SessionsFragment.EXTRA_SCHEDULE_TIME_STRING,
-                    ((BlockView) view).getBlockTimeString());
+            final Intent intent;
+            // Side meetings are 1:1 with a session (same id) — skip the redundant list step.
+            if (ParserUtils.isSideMeetingSessionId(blockId)) {
+                final Uri sessionUri = ScheduleContract.Sessions.buildSessionUri(blockId);
+                intent = new Intent(Intent.ACTION_VIEW, sessionUri);
+            } else {
+                final Uri sessionsUri = ScheduleContract.Blocks.buildSessionsUri(blockId);
+                intent = new Intent(Intent.ACTION_VIEW, sessionsUri);
+                intent.putExtra(SessionsFragment.EXTRA_SCHEDULE_TIME_STRING,
+                        ((BlockView) view).getBlockTimeString());
+            }
             ((BaseActivity) getActivity()).openActivityOrFragment(intent);
         }
     }

--- a/app/src/main/java/org/ietf/ietfsched/ui/SessionAgendaTabManager.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/SessionAgendaTabManager.java
@@ -390,7 +390,37 @@ public class SessionAgendaTabManager {
     }
     
     /**
-     * Show loading message.
+     * Show plain text (e.g. side-meeting description) in the Agenda WebView.
+     * Newlines become &lt;br&gt;; HTML in the source is escaped.
+     */
+    public void showPlainText(String text) {
+        initializeWebView();
+        if (mWebView == null) {
+            return;
+        }
+        String body = text == null ? "" : android.text.TextUtils.htmlEncode(text).replace("\n", "<br>");
+        String html = "<!DOCTYPE html>" +
+            "<html><head>" +
+            "<meta name='viewport' content='width=device-width, initial-scale=1'>" +
+            "<style>" +
+            "body { " +
+            "  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; " +
+            "  font-size: 16px; " +
+            "  line-height: 1.45; " +
+            "  padding: 16px; " +
+            "  color: #222; " +
+            "  white-space: normal; " +
+            "}" +
+            "</style>" +
+            "</head><body>" +
+            body +
+            "</body></html>";
+        mCurrentUrl = null;
+        mWebView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null);
+    }
+
+    /**
+     * Show loading or status message.
      */
     private void showLoadingMessage(String message) {
         if (mWebView == null) {

--- a/app/src/main/java/org/ietf/ietfsched/ui/SessionContentTabBuilder.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/SessionContentTabBuilder.java
@@ -49,6 +49,14 @@ public class SessionContentTabBuilder {
      * Updates the Content tab with Internet drafts and presentation slides.
      */
     public void updateContentTab(Cursor cursor, int pdfUrlIndex, int draftsUrlIndex) {
+        updateContentTab(cursor, pdfUrlIndex, draftsUrlIndex, -1);
+    }
+
+    /**
+     * Updates the Content tab. When {@code abstractIndex} &gt;= 0 and abstract text is present,
+     * it is shown above slides/drafts (used for side meetings).
+     */
+    public void updateContentTab(Cursor cursor, int pdfUrlIndex, int draftsUrlIndex, int abstractIndex) {
         // Find the included view first, then find the container inside it
         View includedView = mRootView.findViewById(R.id.tab_session_summary);
         ViewGroup container = null;
@@ -77,6 +85,22 @@ public class SessionContentTabBuilder {
         if (cursor == null) {
             Log.e(TAG, "updateContentTab: cursor is null!");
             return;
+        }
+
+        if (abstractIndex >= 0) {
+            String abstractText = cursor.getString(abstractIndex);
+            if (!TextUtils.isEmpty(abstractText)) {
+                TextView abstractView = new TextView(mFragment.getActivity());
+                abstractView.setText(abstractText);
+                abstractView.setTextAppearance(mFragment.getActivity(), android.R.style.TextAppearance_Medium);
+                abstractView.setPadding(
+                        mFragment.getResources().getDimensionPixelSize(R.dimen.body_padding_medium),
+                        mFragment.getResources().getDimensionPixelSize(R.dimen.body_padding_medium),
+                        mFragment.getResources().getDimensionPixelSize(R.dimen.body_padding_medium),
+                        mFragment.getResources().getDimensionPixelSize(R.dimen.body_padding_medium));
+                container.addView(abstractView);
+                hasContent = true;
+            }
         }
 
         // First, add Presentation Slides section

--- a/app/src/main/java/org/ietf/ietfsched/ui/SessionDetailFragment.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/SessionDetailFragment.java
@@ -27,6 +27,7 @@ import org.ietf.ietfsched.util.FractionalTouchDelegate;
 import org.ietf.ietfsched.util.GeckoRuntimeHelper;
 import org.ietf.ietfsched.util.GeckoViewHelper;
 import org.ietf.ietfsched.util.NotifyingAsyncQueryHandler;
+import org.ietf.ietfsched.util.ParserUtils;
 import org.ietf.ietfsched.util.UIUtils;
 
 import android.content.BroadcastReceiver;
@@ -126,6 +127,8 @@ public class SessionDetailFragment extends Fragment implements
     private boolean mSpeakersCursor = false;
     private boolean mHasSummaryContent = false;
     private boolean mPendingStarredUpdate = false; // Track if a starred update is in progress
+    /** Ignore Join/side-meeting tab side-effects until TabHost setup has settled. */
+    private boolean mTabHostReady = false;
 
 
     @Override
@@ -253,6 +256,22 @@ public class SessionDetailFragment extends Fragment implements
             @Override
             public void onTabChanged(String tabId) {
                 mCurrentTabTag = tabId;
+                if (!mTabHostReady) {
+                    return;
+                }
+                final boolean isSideMeeting = ParserUtils.isSideMeetingSessionId(mSessionId);
+
+                // Side meetings: Content/Notes disabled; Join opens external URL only on explicit user tap.
+                if (isSideMeeting && (TAG_CONTENT.equals(tabId) || TAG_NOTES.equals(tabId))) {
+                    mTabHost.setCurrentTabByTag(TAG_AGENDA);
+                    return;
+                }
+                if (isSideMeeting && TAG_JOIN.equals(tabId)) {
+                    openSideMeetingJoinExternally();
+                    mTabHost.setCurrentTabByTag(TAG_AGENDA);
+                    return;
+                }
+
                 // Fetch drafts on-demand when Content tab is opened
                 if (TAG_CONTENT.equals(tabId) && mDraftFetcher != null && mSessionId != null) {
                     mDraftFetcher.fetchDraftsOnDemand();
@@ -271,8 +290,9 @@ public class SessionDetailFragment extends Fragment implements
                         }
                     });
                 }
-                // Handle Agenda tab (WebView) - trigger update if needed
-                if (TAG_AGENDA.equals(tabId) && mAgendaTabManager != null && mUrl != null) {
+                // Handle Agenda tab (WebView) - for normal sessions only (side meetings use plain text)
+                if (TAG_AGENDA.equals(tabId) && mAgendaTabManager != null && mUrl != null
+                        && !ParserUtils.isSideMeetingSessionId(mSessionId)) {
                     mTabHost.post(new Runnable() {
                         @Override
                         public void run() {
@@ -302,6 +322,7 @@ public class SessionDetailFragment extends Fragment implements
         final View starParent = mRootView.findViewById(R.id.header_session);
         FractionalTouchDelegate.setupDelegate(starParent, mStarred, new RectF(0.6f, 0f, 1f, 0.8f));
 
+        // Keep existing tab order (unchanged for normal sessions).
         setupAgendaTab();
         setupJoinTab();
         setupContentTab();
@@ -312,6 +333,14 @@ public class SessionDetailFragment extends Fragment implements
         
         // Initialize helper classes after views are created
         initializeHelpers();
+
+        // Allow Join / side-meeting tab actions only after setup settles.
+        mTabHost.post(new Runnable() {
+            @Override
+            public void run() {
+                mTabHostReady = true;
+            }
+        });
 
         return mRootView;
     }
@@ -398,7 +427,10 @@ public class SessionDetailFragment extends Fragment implements
             Log.w(TAG, "updateContentTab: ContentTabBuilder not initialized");
             return;
         }
-        mContentTabBuilder.updateContentTab(cursor, SessionsQuery.PDF_URL, SessionsQuery.DRAFTS_URL);
+        // Side-meeting description lives under Agenda, not Content.
+        int abstractIndex = ParserUtils.isSideMeetingSessionId(mSessionId) ? -1 : SessionsQuery.ABSTRACT;
+        mContentTabBuilder.updateContentTab(cursor, SessionsQuery.PDF_URL, SessionsQuery.DRAFTS_URL,
+                abstractIndex);
     }
 
 
@@ -489,6 +521,12 @@ public class SessionDetailFragment extends Fragment implements
             if (bofLabel != null) {
                 bofLabel.setVisibility(cursor.getInt(SessionsQuery.IS_BOF) != 0 ? View.VISIBLE : View.GONE);
             }
+            final View sideLabel = mRootView.findViewById(R.id.session_side_label);
+            final boolean isSideMeeting = ParserUtils.isSideMeetingSessionId(mSessionId);
+            if (sideLabel != null) {
+                sideLabel.setVisibility(isSideMeeting ? View.VISIBLE : View.GONE);
+            }
+            setSideMeetingTabsGrayed(isSideMeeting);
 
             mUrl = cursor.getString(SessionsQuery.SESSION_URL);
             if (TextUtils.isEmpty(mUrl)) {
@@ -517,23 +555,54 @@ public class SessionDetailFragment extends Fragment implements
             if (mSharedGeckoView == null) {
                 createSharedGeckoView();
             }
-            if (mNotesTabManager != null && mTitleString != null) {
-                mNotesTabManager.updateNotesTab(mTitleString, mSharedGeckoView);
-                // Initialize with shared GeckoView if not already initialized
-                if (mSharedGeckoView != null) {
-                    mNotesTabManager.initializeGeckoView(mSharedGeckoView);
+            if (!isSideMeeting) {
+                if (mNotesTabManager != null && mTitleString != null) {
+                    mNotesTabManager.updateNotesTab(mTitleString, mSharedGeckoView);
+                    if (mSharedGeckoView != null) {
+                        mNotesTabManager.initializeGeckoView(mSharedGeckoView);
+                    }
                 }
-            }
-            if (mJoinTabManager != null && mTitleString != null) {
-                mJoinTabManager.updateJoinTab(mTitleString, mSharedGeckoView);
-                // Initialize with shared GeckoView if not already initialized
-                if (mSharedGeckoView != null) {
-                    mJoinTabManager.initializeGeckoView(mSharedGeckoView);
+                if (mJoinTabManager != null && mTitleString != null) {
+                    mJoinTabManager.updateJoinTab(mTitleString, mSharedGeckoView);
+                    if (mSharedGeckoView != null) {
+                        mJoinTabManager.initializeGeckoView(mSharedGeckoView);
+                    }
                 }
             }
 
         } finally {
             cursor.close();
+        }
+    }
+
+    /** Gray out Content and Notes for side meetings. Agenda shows description; Join stays active. */
+    private void setSideMeetingTabsGrayed(boolean grayed) {
+        if (mTabHost == null) return;
+        android.widget.TabWidget widget = mTabHost.getTabWidget();
+        if (widget == null) return;
+        // Existing tab order: Agenda(0), Join(1), Content(2), Notes(3)
+        for (int index : new int[]{2, 3}) {
+            if (index >= widget.getChildCount()) continue;
+            View tab = widget.getChildAt(index);
+            tab.setEnabled(!grayed);
+            tab.setAlpha(grayed ? 0.4f : 1f);
+            tab.setClickable(!grayed);
+        }
+    }
+
+    private void openSideMeetingJoinExternally() {
+        if (TextUtils.isEmpty(mUrl)) {
+            android.widget.Toast.makeText(getActivity(),
+                    "No join link available for this side meeting.",
+                    android.widget.Toast.LENGTH_SHORT).show();
+            return;
+        }
+        try {
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(mUrl));
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
+            startActivity(intent);
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to open side meeting join URL: " + mUrl, e);
         }
     }
 
@@ -794,10 +863,16 @@ public class SessionDetailFragment extends Fragment implements
 
     /**
      * Updates the Agenda tab with the agenda URL.
+     * For side meetings, SESSION_URL is the Join link — show description here instead.
      */
     private void updateAgendaTab(Cursor cursor) {
         if (mAgendaTabManager == null) {
             Log.w(TAG, "updateAgendaTab: AgendaTabManager not initialized");
+            return;
+        }
+        if (ParserUtils.isSideMeetingSessionId(mSessionId)) {
+            String description = cursor.getString(SessionsQuery.ABSTRACT);
+            mAgendaTabManager.showPlainText(description != null ? description : "");
             return;
         }
         String agendaUrl = cursor.getString(SessionsQuery.SESSION_URL);

--- a/app/src/main/java/org/ietf/ietfsched/ui/SessionsFragment.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/SessionsFragment.java
@@ -19,6 +19,7 @@ import org.ietf.ietfsched.R;
 import org.ietf.ietfsched.provider.ScheduleContract;
 import org.ietf.ietfsched.util.ActivityHelper;
 import org.ietf.ietfsched.util.NotifyingAsyncQueryHandler;
+import org.ietf.ietfsched.util.ParserUtils;
 import org.ietf.ietfsched.util.UIUtils;
 
 import android.content.Context;
@@ -397,6 +398,12 @@ public class SessionsFragment extends ListFragment implements NotifyingAsyncQuer
             final View bofLabel = view.findViewById(R.id.session_bof_label);
             bofLabel.setVisibility(cursor.getInt(SessionsQuery.IS_BOF) != 0 ? View.VISIBLE : View.GONE);
 
+            final View sideLabel = view.findViewById(R.id.session_side_label);
+            if (sideLabel != null) {
+                sideLabel.setVisibility(
+                        ParserUtils.isSideMeetingSessionId(sessionId) ? View.VISIBLE : View.GONE);
+            }
+
             // Possibly indicate that the session has occurred in the past.
             UIUtils.setSessionTitleColor(blockEnd, titleView, subtitleView);
         }
@@ -472,6 +479,12 @@ public class SessionsFragment extends ListFragment implements NotifyingAsyncQuer
             // Show BoF label for Birds of a Feather sessions
             final View bofLabel = view.findViewById(R.id.session_bof_label);
             bofLabel.setVisibility(cursor.getInt(SearchQuery.IS_BOF) != 0 ? View.VISIBLE : View.GONE);
+
+            final View sideLabel = view.findViewById(R.id.session_side_label);
+            if (sideLabel != null) {
+                sideLabel.setVisibility(
+                        ParserUtils.isSideMeetingSessionId(sessionId) ? View.VISIBLE : View.GONE);
+            }
         }
     }
 

--- a/app/src/main/java/org/ietf/ietfsched/ui/widget/BlockView.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/widget/BlockView.java
@@ -48,9 +48,16 @@ public class BlockView extends Button {
     private final long mEndTime;
     private final boolean mContainsStarred;
     private final int mColumn;
+    private final int mSubColumn;
+    private boolean mHalfWidth;
 
     public BlockView(Context context, String blockId, String title, long startTime,
             long endTime, boolean containsStarred, int column) {
+        this(context, blockId, title, startTime, endTime, containsStarred, column, 0);
+    }
+
+    public BlockView(Context context, String blockId, String title, long startTime,
+            long endTime, boolean containsStarred, int column, int subColumn) {
         super(context);
 
         mBlockId = blockId;
@@ -59,6 +66,8 @@ public class BlockView extends Button {
         mEndTime = endTime;
         mContainsStarred = containsStarred;
         mColumn = column;
+        mSubColumn = subColumn;
+        mHalfWidth = false;
 
         setText(mTitle);
         
@@ -115,5 +124,17 @@ public class BlockView extends Button {
 
     public int getColumn() {
         return mColumn;
+    }
+
+    public int getSubColumn() {
+        return mSubColumn;
+    }
+
+    public boolean isHalfWidth() {
+        return mHalfWidth;
+    }
+
+    public void setHalfWidth(boolean halfWidth) {
+        mHalfWidth = halfWidth;
     }
 }

--- a/app/src/main/java/org/ietf/ietfsched/ui/widget/BlocksLayout.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/widget/BlocksLayout.java
@@ -122,8 +122,17 @@ public class BlocksLayout extends ViewGroup {
                 final long endTime = blockView.getEndTime();
                 final int top = rulerView.getTimeVerticalOffset(startTime, i, true);
                 final int bottom = rulerView.getTimeVerticalOffset(endTime, i, false);
-                final int left = headerWidth + (blockView.getColumn() * columnWidth);
-                final int right = left + columnWidth;
+                final int columnLeft = headerWidth + (blockView.getColumn() * columnWidth);
+                final int left;
+                final int right;
+                if (blockView.isHalfWidth()) {
+                    final int half = columnWidth / 2;
+                    left = columnLeft + (blockView.getSubColumn() * half);
+                    right = left + half;
+                } else {
+                    left = columnLeft;
+                    right = left + columnWidth;
+                }
                 child.layout(left, top, right, bottom);
             }
         }

--- a/app/src/main/java/org/ietf/ietfsched/util/ParserUtils.java
+++ b/app/src/main/java/org/ietf/ietfsched/util/ParserUtils.java
@@ -46,7 +46,26 @@ public class ParserUtils {
     public static final String BLOCK_TYPE_OFFICE_HOURS = "officehours";
     public static final String BLOCK_TYPE_NOC_HELPDESK = "nocHelpdesk";
     public static final String BLOCK_TYPE_HACKATHON = "hackathon";
+    /** Green-column side meetings; optional trailing 0/1 encodes room sub-column. */
+    public static final String BLOCK_TYPE_SIDE_MEETING = "sidemeeting";
     public static final String BLOCK_TYPE_UNKNOWN = "unknown";
+
+    public static boolean isSideMeetingBlockType(String blockType) {
+        return blockType != null && blockType.startsWith(BLOCK_TYPE_SIDE_MEETING);
+    }
+
+    /** Room sub-column (0 or 1) encoded as trailing digit on sidemeeting block types. */
+    public static int sideMeetingSubColumn(String blockType) {
+        if (!isSideMeetingBlockType(blockType) || blockType.length() <= BLOCK_TYPE_SIDE_MEETING.length()) {
+            return 0;
+        }
+        char c = blockType.charAt(blockType.length() - 1);
+        return c == '1' ? 1 : 0;
+    }
+
+    public static boolean isSideMeetingSessionId(String sessionId) {
+        return sessionId != null && sessionId.startsWith("side-");
+    }
 
     /** Used to sanitize a string to be {@link Uri} safe. */
     private static final Pattern sSanitizePattern = Pattern.compile("[^a-z0-9-_]");

--- a/app/src/main/res/drawable/side_label_bg.xml
+++ b/app/src/main/res/drawable/side_label_bg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Green background for Side meeting label (matches schedule green column) -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#009939" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -63,6 +63,19 @@
                 android:textColor="@android:color/white"
                 android:textSize="12sp"
                 android:visibility="gone" />
+            <TextView android:id="@+id/session_side_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:background="@drawable/side_label_bg"
+                android:paddingStart="6dp"
+                android:paddingEnd="6dp"
+                android:paddingTop="2dp"
+                android:paddingBottom="2dp"
+                android:text="@string/side_label"
+                android:textColor="@android:color/white"
+                android:textSize="12sp"
+                android:visibility="gone" />
         </LinearLayout>
 
         <TextView android:id="@+id/session_subtitle"

--- a/app/src/main/res/layout/list_item_session.xml
+++ b/app/src/main/res/layout/list_item_session.xml
@@ -58,6 +58,20 @@
                 android:textSize="11sp"
                 android:visibility="gone"
                 tools:visibility="visible" />
+            <TextView android:id="@+id/session_side_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="6dp"
+                android:background="@drawable/side_label_bg"
+                android:paddingStart="6dp"
+                android:paddingEnd="6dp"
+                android:paddingTop="2dp"
+                android:paddingBottom="2dp"
+                android:text="@string/side_label"
+                android:textColor="@android:color/white"
+                android:textSize="11sp"
+                android:visibility="gone"
+                tools:visibility="visible" />
         </LinearLayout>
         <TextView android:id="@+id/session_subtitle"
             android:layout_below="@id/session_title_row"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="description_export">Export</string>
     <string name="description_star">Star</string>
     <string name="bof_label">BoF</string>
+    <string name="side_label">Side</string>
     <string name="description_now">Go to Now</string>
 
     <string name="title_now_playing">Now Playing</string>

--- a/dev-docs/SIDE_MEETINGS_PLAN.md
+++ b/dev-docs/SIDE_MEETINGS_PLAN.md
@@ -1,303 +1,162 @@
-# Plan: Side Meetings in Schedule + Sessions
+# Side Meetings — Design (as built)
 
-Status: **Draft for review** (feedback incorporated; not yet implemented)  
-Target meeting: IETF 126 (Vienna, 2026-07-20 … 2026-07-24)  
+Status: **Implemented** (IETF 126)  
+Branch: `ys-side-meetings`  
 Data: [https://sidemeetings.ietf.org/](https://sidemeetings.ietf.org/) · informal API [https://sidemeetings.ietf.org/_data](https://sidemeetings.ietf.org/_data)
 
-Local Android cmdline tools (this machine):
+Local tooling (this workstation):
 
 ```text
 C:\Users\yaron\Applications\android-cmdline-tools
+C:\Users\yaron\Applications\Android\Sdk
+Microsoft OpenJDK 17 (JAVA_HOME)
 ```
+
+Emulator is **not** available on Windows ARM64; use a physical device (Pixel 8a) + optional scrcpy.
 
 ---
 
 ## Goal
 
-Show IETF **side meetings** in the app’s **Sessions** list and on the **Schedule** grid by **repurposing the green column** for them.
-
-Side meetings differ from WG sessions:
-
-- Start/end times are **arbitrary** (not aligned with “Mon Session I/II/III”).
-- There are only **two rooms**, so at most **two** side meetings run in parallel.
-- Remote join info is usually a Webex/Zoom URL, not Meetecho.
-
-Rationale for reclaiming green: other than Sunday, the green column is **mostly blank** today, so it is a natural home for side meetings during the week.
+Show IETF **side meetings** in **Sessions** and on the **Schedule** grid by **repurposing the green column**.
 
 ---
 
-## Constraints from data + existing UI
+## Coverage checklist (plan → reality)
 
-| Fact | Implication |
-|------|-------------|
-| Bookings have arbitrary `start` / `end` (UTC ISO) | Each side meeting is its own time block, not folded into official session slots |
-| Exactly two rooms (e.g. Park Suite 4, Grand Klimt Hall 3); ≤2 in parallel | Green column must support **two overlapping** blocks without painting over each other |
-| Green today = `officehours` (registration, staff office hours, education/newcomer, …) | **Drop registration**; relocate remaining items out of green → **yellow** (see §6) |
-| Schedule grid = 4 **semantic** columns (not rooms/tracks) | Side meetings map to column 2 (green); room only matters for stacking within that column |
-| API `location` is usually a **Webex/Zoom URL**, not the room name | Detail “Join” opens that URL externally; physical room comes from `roomName` |
-| `/_data` is an **informal** API | Fail gracefully: short timeout, no blocking wait, continue agenda sync if side-meetings fetch fails or returns junk |
-
-### Current schedule columns (today)
-
-| Col | Color | `block_type` | Typical content |
-|-----|-------|--------------|-----------------|
-| 0 Blue | `#0fabff` | `food` | Breaks, plenary, reception/social |
-| 1 Red | `#df1831` | `session`, `hackathon` | Numbered WG sessions, hackathon |
-| 2 Green | `#009939` | `officehours` | Registration, staff OH, education/newcomer/tools/… (sparse Mon–Fri) |
-| 3 Yellow | `#F4BE36` | `nocHelpdesk` | NOC/helpdesk, AD office hours, IEPG |
-
-Green is column index 2 in `ScheduleFragment.buildTypeColumnMap()`, colored via `block_column_3`.
-
-### API shape (`/_data`)
-
-```json
-{
-  "meeting": {
-    "meetingNumber": "126",
-    "meetingLocation": "…",
-    "startDate": "YYYY-MM-DD",
-    "endDate": "YYYY-MM-DD",
-    "timezone": "Europe/Vienna"
-  },
-  "rooms": [
-    { "id": …, "title": "…", "description": "…", "slug": "…" }
-  ],
-  "bookings": [
-    {
-      "id": …,
-      "roomId": …,
-      "roomName": "Park Suite 4",
-      "title": "…",
-      "description": "…",
-      "start": "2026-07-20T07:00:00.000Z",
-      "end": "2026-07-20T08:00:00.000Z",
-      "location": "https://ietf.webex.com/meet/…",
-      "organizerName": "…",
-      "organizerEmail": "…",
-      "areas": ["RTG"]
-    }
-  ]
-}
-```
-
-Notes:
-
-- Endpoint appears to always expose the **current** side-meetings meeting (no `{number}` in the URL).
-- Times are UTC; the app stores/displays times in the **meeting timezone**.
-- Empty, mismatched, broken, or slow responses must not break or delay the rest of sync.
+| Plan item | Status | Notes |
+|-----------|--------|-------|
+| Soft-fetch `/_data` with short timeout | Done | 4s connect / 6s read; agenda sync continues on failure |
+| Meeting-number guard vs `MeetingDetector` | Done | Skip import if `_data` ≠ active meeting |
+| Same `UPDATED` purge stamp as agenda | Done | `SideMeetingImporter` ops merged into `LocalExecutor` batch |
+| Preserve stars | Done | Same `querySessionStarred` pattern |
+| `side-{id}` session/block ids | Done | Prefix detection; no schema migration |
+| Block type `sidemeeting` (+ room digit) | Done | `sidemeeting0` / `sidemeeting1` |
+| Green column = side meetings only | Done | |
+| Drop registration | Done | Skipped in `LocalExecutor.transform` |
+| Former green → yellow | Done | Remapped to `nocHelpdesk` |
+| Half-width when two overlap | Done | Full width when alone |
+| Side badge (BoF-style) | Done | List + detail; green `#009939` |
+| Join = external URL (not Meetecho) | Done | `ACTION_VIEW` on `SESSION_URL` |
+| Informal API never blocks agenda | Done | Soft-fail smoke-tested on Pixel 8a (see below) |
+| Schedule tap → session list | **Changed** | Direct to **session detail** (1:1) |
+| Description in Content; Notes+Agenda grayed | **Changed** | Description in **Agenda**; **Content + Notes** grayed |
+| Docs (`OVERVIEW`, `IMPLEMENTATION_NOTES`) | **Not done** | Still pending |
+| Espresso regression cases | **Skipped** | Informal API; revisit when official |
 
 ---
 
-## Recommended design
+## As-built behavior
 
-### 1. Sync: fetch side meetings with agenda
+### Schedule columns
 
-Use the **same meeting association** as the rest of the app: whatever `MeetingDetector` selects as the active meeting (ongoing / upcoming / previous fallback). Side meetings are imported only when they belong to that meeting.
+| Col | Color | Content |
+|-----|-------|---------|
+| 0 Blue | food / breaks / plenary / social | Unchanged |
+| 1 Red | WG sessions / hackathon | Unchanged |
+| 2 Green | **Side meetings** (`sidemeeting` / `sidemeeting0` / `sidemeeting1`) | New |
+| 3 Yellow | NOC / helpdesk / AD OH / IEPG + former green leftovers (staff OH, education/newcomer/tools, hackathon results, …) | Registration omitted |
 
-In `SyncService`, after (or alongside) agenda sync:
+### Sync
 
-1. GET `https://sidemeetings.ietf.org/_data` with a **short timeout**; never block the main agenda path on this call
-2. On network/parse/timeout errors → log, skip side meetings, leave existing agenda data intact
-3. If `meeting.meetingNumber` ≠ detected meeting → **skip import** and log (same “wrong week” safety as agenda association)
-4. Parse `rooms` + `bookings` into the existing SQLite model (blocks + rooms + sessions)
-5. Use the same sync `UPDATED` timestamp so stale side meetings are purged like agenda rows
-6. Preserve `SESSION_STARRED` across replace (same as agenda sessions)
+1. After agenda JSON fetch, soft-GET `https://sidemeetings.ietf.org/_data`.
+2. `SideMeetingImporter.buildOperations(...)` only if meeting numbers match.
+3. Ops applied in the **same** batch / purge as agenda (`LocalExecutor.execute(agenda, number, sideData)`).
 
-Prefer a small dedicated importer (e.g. `SideMeetingImporter`) rather than stretching agenda `Meeting` / `LocalExecutor` JSON parsing.
+**Key files:** `SyncService.java`, `RemoteExecutor.java` (timeouts), `SideMeetingImporter.java`, `LocalExecutor.java`.
 
-**Relevant existing files:**
-
-- `app/src/main/java/org/ietf/ietfsched/service/SyncService.java`
-- `app/src/main/java/org/ietf/ietfsched/io/RemoteExecutor.java`
-- `app/src/main/java/org/ietf/ietfsched/io/LocalExecutor.java`
-- `app/src/main/java/org/ietf/ietfsched/io/MeetingDetector.java`
-
-### 2. Data mapping (bookings → sessions)
+### Data mapping
 
 | API field | App field |
 |-----------|-----------|
-| `id` | Stable session key, e.g. `side-{id}` |
-| `title` | Session title (**no** `SIDE -` text prefix; use a badge — see §4) |
-| `start` / `end` | Block + session times (UTC → meeting TZ) |
+| `id` | Session + block id `side-{id}` (sanitized) |
+| `title` | Session / block title (no `SIDE -` prefix) |
+| `start` / `end` | Absolute millis via `Instant.parse` (UTC ISO) |
 | `roomName` | Room |
-| `description` | Detail body (Content tab) |
-| `location` | Join / remote URL (opened externally) |
-| `organizerName` (+ email) | Subtitle / detail metadata |
-| `areas[]` | Tags / search text |
+| `description` + organizer + areas | `SESSION_ABSTRACT` (shown in **Agenda** tab) |
+| `location` | `SESSION_URL` (Join external link) |
+| `areas[]` | `SESSION_KEYWORDS` |
 
-Each booking → **one block + one session** (1:1).
+Room sub-column: rooms from `_data` sorted by title → index 0/1 → block type suffix.
 
-Introduce a dedicated block type, e.g. `sidemeeting` (cleaner than overloading `officehours`).
+### Schedule UX
 
-Constants live near other block types in `ParserUtils` (`BLOCK_TYPE_OFFICE_HOURS`, etc.).
+- Chip title = booking title.
+- Overlap → half-width by room sub-column; alone → full green width.
+- **Tap green chip → session detail directly** (skips one-item list).
 
-### 3. Schedule: green column = side meetings
+### Sessions list
 
-Keep **four** columns; repurpose column 2:
+- Appears in Sessions / search / starred.
+- Green **Side** badge (like BoF).
 
-| Col | Color | Content after change |
-|-----|-------|----------------------|
-| 0 Blue | food / breaks / plenary / social | Unchanged |
-| 1 Red | WG sessions / hackathon | Unchanged |
-| 2 Green | **Side meetings only** (`sidemeeting`) | New |
-| 3 Yellow | NOC / helpdesk / AD OH / IEPG + **former green leftovers** (staff OH, education/newcomer/tools, hackathon results, …) | Expanded; registration omitted |
+### Session detail (side meetings only)
 
-#### Parallel layout (required)
+Existing tab order unchanged: **Agenda · Join · Content · Notes**.
 
-`BlocksLayout` currently lays out each `BlockView` as full column width:
+| Tab | Behavior |
+|-----|----------|
+| Agenda | Description + organizer + areas (plain text in WebView) |
+| Join | Opens `SESSION_URL` externally (`ACTION_VIEW`). Webex may itself redirect to Play Store if the app is not installed — left as-is |
+| Content | Grayed |
+| Notes | Grayed |
 
-```text
-left = headerWidth + column * columnWidth
-right = left + columnWidth
-```
+TabHost setup can fire spurious changes; Join action is gated until `mTabHostReady`.
 
-Two overlapping green blocks would cover each other.
+### Registration / former green
 
-**Fix:**
-
-- Assign each side meeting a **sub-column 0 or 1** by room (stable sort of the two room titles/slugs from `_data.rooms`).
-- For `sidemeeting` blocks:
-  - **Full width** when alone in that time range
-  - **Half width** when two overlap:
-    - `left = headerWidth + column*columnWidth + sub*half`
-    - `width = columnWidth / 2`
-
-Block chip title: truncated booking title (not “Mon Session II”).  
-Tap → existing `SessionsFragment` for that `block_id` (usually one session).
-
-**Relevant files:**
-
-- `app/src/main/java/org/ietf/ietfsched/ui/ScheduleFragment.java`
-- `app/src/main/java/org/ietf/ietfsched/ui/widget/BlocksLayout.java`
-- `app/src/main/java/org/ietf/ietfsched/ui/widget/BlockView.java`
-- `app/src/main/res/values/colors.xml` (`block_column_3` green)
-
-### 4. Sessions list — badge like BoF (not a title prefix)
-
-Side meetings are normal `sessions` rows (list, search/FTS, starred).
-
-**Labeling:** mirror the existing **BoF** treatment — a small badge on the list row and detail header — not a `SIDE - …` title prefix.
-
-Existing pattern:
-
-- DB: `SESSION_IS_BOF`
-- UI: `session_bof_label` in `list_item_session.xml` / `fragment_session_detail.xml`
-- String: `bof_label` (“BoF”)
-
-For side meetings, use the same approach:
-
-- Detect via session id prefix `side-…` **or** a small `SESSION_IS_SIDE_MEETING` flag (prefix is enough for v1; flag optional if badge wiring is cleaner)
-- Add a **Side** (or **SIDE**) badge next to / analogous to the BoF badge
-- Keep the session title as the booking title (areas can stay in subtitle/search text)
-
-**Relevant files:**
-
-- `app/src/main/java/org/ietf/ietfsched/ui/SessionsFragment.java`
-- `app/src/main/res/layout/list_item_session.xml`
-- `app/src/main/res/layout/fragment_session_detail.xml`
-- `app/src/main/res/values/strings.xml`
-- (optional) drawable similar to `bof_label_bg.xml`
-
-### 5. Session detail (side-meeting-aware)
-
-Reuse `SessionDetailFragment` with light branching when the session is a side meeting:
-
-| Tab | Behavior for side meetings |
-|-----|----------------------------|
-| Content | Show `description` + organizer; skip slides/drafts when empty |
-| Notes | **Grayed out** (visible but disabled / non-interactive) |
-| Agenda | **Grayed out** (same) |
-| Join | Open API `location` as an **external** URL (browser / apps that handle the link) — **not** in-app WebView, and **not** Meetecho constructed from a group acronym |
-
-**Relevant files:**
-
-- `app/src/main/java/org/ietf/ietfsched/ui/SessionDetailFragment.java`
-- `app/src/main/java/org/ietf/ietfsched/ui/SessionJoinTabManager.java`
-- `app/src/main/java/org/ietf/ietfsched/ui/SessionNotesTabManager.java`
-- `app/src/main/java/org/ietf/ietfsched/ui/SessionContentTabBuilder.java`
-
-### 6. Drop registration; relocate remaining green items → **yellow**
-
-**Omit registration entirely** — do not create a block/session for registration (or purge if already present). It is a long, low-value schedule chip attendees rarely need.
-
-For everything else that currently uses `BLOCK_TYPE_OFFICE_HOURS`, remap → `BLOCK_TYPE_NOC_HELPDESK` (**yellow**):
-
-- Staff office hours (non-AD; AD already yellow)
-- Education / newcomer / tools / chairs / forum / etc.
-- Hackathon results / presentations (today forced into green to avoid red overlap)
-
-Green is reserved for `sidemeeting`. Blue stays food/breaks/social only.
-
-**Trade-off:** yellow gets a bit busier (service/admin cluster), but dropping registration removes the worst long-running collision source, and blue stays visually clean for meals/breaks.
+- Registration: not imported.
+- Former `officehours` content → `nocHelpdesk` (yellow).
 
 ---
 
-## Implementation outline
+## Known limitations / non-goals
 
-Suggested order:
-
-1. **Parser + sync** — short-timeout fetch of `_data`, map bookings → ContentProvider ops, purge, meeting-number guard aligned with `MeetingDetector`, fail soft
-2. **Block type + column map** — `sidemeeting` → column 2; drop registration; relocate remaining `officehours` → **yellow** (`nocHelpdesk`)
-3. **Overlapping layout** — room-based half-width when two side meetings overlap; full-width when alone
-4. **List / detail UX** — Side badge (BoF-style); description; grayed Notes/Agenda; external Join URL
-5. **Docs + tests** — update overview/notes; add Espresso cases (green chips, badge, detail, external join)
-6. **Manual check** on device/emulator with live IETF 126 data before the meeting
-
-### Build / test reminder (this workstation)
-
-Android cmdline tools:
-
-```text
-C:\Users\yaron\Applications\android-cmdline-tools
-```
-
-Also see `BUILD_AND_TEST.md` and `REGRESSION_TEST_PLAN.md` for project-specific Gradle / Espresso flows.
+- No in-app Join WebView / no blocking of Webex→Play Store redirects (explicitly declined).
+- No historical side meetings for other IETF numbers (`/_data` is current-meeting-oriented).
+- No ICS export, no request/edit flow.
+- No Espresso coverage yet (deferred while `/_data` is informal); no updates yet to `OVERVIEW.md` / `IMPLEMENTATION_NOTES.md`.
+- Windows ARM64: no Google Emulator package; device + scrcpy for UI work.
 
 ---
 
-## Decisions (resolved from review)
+## Success criteria (current)
 
-1. **Registration** — **Drop** from schedule/sessions (do not import).
-2. **Where remaining former green items go** — **Yellow** (`nocHelpdesk`). Blue stays food/breaks/social.
-3. **Half-width policy** — Full-width when alone; half-width when two overlap.
-4. **Meeting-number mismatch** — Skip import if `_data` ≠ detected meeting.
-5. **Schema** — Session-id prefix `side-{id}` for v1 (optional explicit flag later if useful for the badge).
-6. **Sessions list labeling** — **BoF-style badge** (“Side” / “SIDE”), not a title prefix.
-7. **Informal API resilience** — Short timeout, no wait on failure, agenda sync unaffected.
-8. **Meeting association** — Same `MeetingDetector` previous/next/ongoing logic as agenda.
-9. **Notes / Agenda tabs** — Grayed out (not hidden).
-10. **Join** — External URL only.
-
----
-
-## Out of scope (for this pass)
-
-- Editing / requesting side meetings in-app
-- Calendar `.ics` export from the app (site already offers ICS)
-- Fifth schedule column
-- Offline-first redesign beyond normal sync caching
-- Showing historical side meetings for past IETF numbers (API is current-meeting-oriented)
+- [x] Green column shows side meetings for the active meeting
+- [x] Overlapping side meetings half-width; alone full-width
+- [x] Sessions list + search + Side badge + starring
+- [x] Agenda shows description; Content/Notes grayed; Join opens remote URL
+- [x] Schedule chip opens detail directly
+- [x] Registration omitted; former green items in yellow
+- [x] Soft-fail `/_data` without blocking agenda sync (device smoke tests below)
+- [ ] Dev-docs follow-up (`OVERVIEW`, `IMPLEMENTATION_NOTES`)
+- [ ] Espresso cases — **skipped for now** (informal `/_data` API; revisit when official)
 
 ---
 
-## Success criteria
+## Device smoke tests (soft-fail)
 
-- Green column shows side meetings for the active IETF meeting, with correct local times and rooms.
-- Two overlapping side meetings are both visible/tappable (half-width by room); single ones use full green width.
-- Side meetings appear in Sessions + search with a Side badge; can be starred.
-- Detail shows description; Notes/Agenda grayed; Join opens the remote URL outside the app.
-- Registration does **not** appear in schedule or sessions.
-- Remaining former green agenda items still appear (in **yellow**), not dropped.
-- Sync remains resilient if `_data` is empty, unreachable, slow, or for another meeting number — without delaying agenda sync.
+Run on Pixel 8a (`adb` + scrcpy). Method: temporary code change → `assembleDebug` → `adb install -r` → `pm clear` → launch → check logcat → restore production URL/code and reinstall.
+
+| Case | How forced | Expected log | Observed |
+|------|------------|--------------|----------|
+| Meeting-number mismatch | Pass `meetingNumber + 999` into `SideMeetingImporter.buildOperations` | `Skipping side meetings: data is for IETF 126 but app meeting is …` then `remote sync finished` | Pass |
+| Bad / empty `/_data` | Point `SIDE_MEETINGS_URL` at a non-existent path | `Side meetings fetch returned empty data` then `remote sync finished` | Pass |
+| Connect timeout | Point URL at `https://192.0.2.1/_data` (TEST-NET blackhole) | `Side meetings fetch failed (continuing without them): … after 4000ms` then `remote sync finished` | Pass (~4s connect timeout) |
+| Happy path (restore) | Real `https://sidemeetings.ietf.org/_data` | `Prepared N ops for M side bookings` then `remote sync finished` | Pass (`117` ops / `39` bookings for IETF 126) |
+
+Also verified earlier by hand on device: green column / half-width overlap, Side badge, detail tabs (Agenda text, Content+Notes grayed, Join external), schedule chip → detail directly.
+
+**Notes**
+
+- Soft-fail paths must not prevent `remote sync finished` or leave the UI hung.
+- After any forced-URL test, restore `SIDE_MEETINGS_URL` and reinstall before leaving the phone.
+- Cache TTL can skip sync on relaunch; use `pm clear` (or bump `VERSION_CURRENT`) when forcing a fresh fetch.
 
 ---
 
-## Doc index update
+## Follow-ups
 
-After implementation, also update:
-
-- `OVERVIEW.md` — feature list + API endpoints
-- `IMPLEMENTATION_NOTES.md` — technical section
-- `REGRESSION_TEST_PLAN.md` — new Espresso scenarios
-
-(`OVERVIEW.md` still links to `CHANGES_LOG.md`, which is missing; optional cleanup when touching docs.)
+1. Update `OVERVIEW.md` and `IMPLEMENTATION_NOTES.md`.
+2. Espresso for side meetings: deferred until the side-meetings API is official.
+3. Optional: force a sync path when `VERSION_CURRENT` bumps so side meetings refresh without waiting for cache TTL / `pm clear`.

--- a/dev-docs/SIDE_MEETINGS_PLAN.md
+++ b/dev-docs/SIDE_MEETINGS_PLAN.md
@@ -1,0 +1,303 @@
+# Plan: Side Meetings in Schedule + Sessions
+
+Status: **Draft for review** (feedback incorporated; not yet implemented)  
+Target meeting: IETF 126 (Vienna, 2026-07-20 … 2026-07-24)  
+Data: [https://sidemeetings.ietf.org/](https://sidemeetings.ietf.org/) · informal API [https://sidemeetings.ietf.org/_data](https://sidemeetings.ietf.org/_data)
+
+Local Android cmdline tools (this machine):
+
+```text
+C:\Users\yaron\Applications\android-cmdline-tools
+```
+
+---
+
+## Goal
+
+Show IETF **side meetings** in the app’s **Sessions** list and on the **Schedule** grid by **repurposing the green column** for them.
+
+Side meetings differ from WG sessions:
+
+- Start/end times are **arbitrary** (not aligned with “Mon Session I/II/III”).
+- There are only **two rooms**, so at most **two** side meetings run in parallel.
+- Remote join info is usually a Webex/Zoom URL, not Meetecho.
+
+Rationale for reclaiming green: other than Sunday, the green column is **mostly blank** today, so it is a natural home for side meetings during the week.
+
+---
+
+## Constraints from data + existing UI
+
+| Fact | Implication |
+|------|-------------|
+| Bookings have arbitrary `start` / `end` (UTC ISO) | Each side meeting is its own time block, not folded into official session slots |
+| Exactly two rooms (e.g. Park Suite 4, Grand Klimt Hall 3); ≤2 in parallel | Green column must support **two overlapping** blocks without painting over each other |
+| Green today = `officehours` (registration, staff office hours, education/newcomer, …) | **Drop registration**; relocate remaining items out of green → **yellow** (see §6) |
+| Schedule grid = 4 **semantic** columns (not rooms/tracks) | Side meetings map to column 2 (green); room only matters for stacking within that column |
+| API `location` is usually a **Webex/Zoom URL**, not the room name | Detail “Join” opens that URL externally; physical room comes from `roomName` |
+| `/_data` is an **informal** API | Fail gracefully: short timeout, no blocking wait, continue agenda sync if side-meetings fetch fails or returns junk |
+
+### Current schedule columns (today)
+
+| Col | Color | `block_type` | Typical content |
+|-----|-------|--------------|-----------------|
+| 0 Blue | `#0fabff` | `food` | Breaks, plenary, reception/social |
+| 1 Red | `#df1831` | `session`, `hackathon` | Numbered WG sessions, hackathon |
+| 2 Green | `#009939` | `officehours` | Registration, staff OH, education/newcomer/tools/… (sparse Mon–Fri) |
+| 3 Yellow | `#F4BE36` | `nocHelpdesk` | NOC/helpdesk, AD office hours, IEPG |
+
+Green is column index 2 in `ScheduleFragment.buildTypeColumnMap()`, colored via `block_column_3`.
+
+### API shape (`/_data`)
+
+```json
+{
+  "meeting": {
+    "meetingNumber": "126",
+    "meetingLocation": "…",
+    "startDate": "YYYY-MM-DD",
+    "endDate": "YYYY-MM-DD",
+    "timezone": "Europe/Vienna"
+  },
+  "rooms": [
+    { "id": …, "title": "…", "description": "…", "slug": "…" }
+  ],
+  "bookings": [
+    {
+      "id": …,
+      "roomId": …,
+      "roomName": "Park Suite 4",
+      "title": "…",
+      "description": "…",
+      "start": "2026-07-20T07:00:00.000Z",
+      "end": "2026-07-20T08:00:00.000Z",
+      "location": "https://ietf.webex.com/meet/…",
+      "organizerName": "…",
+      "organizerEmail": "…",
+      "areas": ["RTG"]
+    }
+  ]
+}
+```
+
+Notes:
+
+- Endpoint appears to always expose the **current** side-meetings meeting (no `{number}` in the URL).
+- Times are UTC; the app stores/displays times in the **meeting timezone**.
+- Empty, mismatched, broken, or slow responses must not break or delay the rest of sync.
+
+---
+
+## Recommended design
+
+### 1. Sync: fetch side meetings with agenda
+
+Use the **same meeting association** as the rest of the app: whatever `MeetingDetector` selects as the active meeting (ongoing / upcoming / previous fallback). Side meetings are imported only when they belong to that meeting.
+
+In `SyncService`, after (or alongside) agenda sync:
+
+1. GET `https://sidemeetings.ietf.org/_data` with a **short timeout**; never block the main agenda path on this call
+2. On network/parse/timeout errors → log, skip side meetings, leave existing agenda data intact
+3. If `meeting.meetingNumber` ≠ detected meeting → **skip import** and log (same “wrong week” safety as agenda association)
+4. Parse `rooms` + `bookings` into the existing SQLite model (blocks + rooms + sessions)
+5. Use the same sync `UPDATED` timestamp so stale side meetings are purged like agenda rows
+6. Preserve `SESSION_STARRED` across replace (same as agenda sessions)
+
+Prefer a small dedicated importer (e.g. `SideMeetingImporter`) rather than stretching agenda `Meeting` / `LocalExecutor` JSON parsing.
+
+**Relevant existing files:**
+
+- `app/src/main/java/org/ietf/ietfsched/service/SyncService.java`
+- `app/src/main/java/org/ietf/ietfsched/io/RemoteExecutor.java`
+- `app/src/main/java/org/ietf/ietfsched/io/LocalExecutor.java`
+- `app/src/main/java/org/ietf/ietfsched/io/MeetingDetector.java`
+
+### 2. Data mapping (bookings → sessions)
+
+| API field | App field |
+|-----------|-----------|
+| `id` | Stable session key, e.g. `side-{id}` |
+| `title` | Session title (**no** `SIDE -` text prefix; use a badge — see §4) |
+| `start` / `end` | Block + session times (UTC → meeting TZ) |
+| `roomName` | Room |
+| `description` | Detail body (Content tab) |
+| `location` | Join / remote URL (opened externally) |
+| `organizerName` (+ email) | Subtitle / detail metadata |
+| `areas[]` | Tags / search text |
+
+Each booking → **one block + one session** (1:1).
+
+Introduce a dedicated block type, e.g. `sidemeeting` (cleaner than overloading `officehours`).
+
+Constants live near other block types in `ParserUtils` (`BLOCK_TYPE_OFFICE_HOURS`, etc.).
+
+### 3. Schedule: green column = side meetings
+
+Keep **four** columns; repurpose column 2:
+
+| Col | Color | Content after change |
+|-----|-------|----------------------|
+| 0 Blue | food / breaks / plenary / social | Unchanged |
+| 1 Red | WG sessions / hackathon | Unchanged |
+| 2 Green | **Side meetings only** (`sidemeeting`) | New |
+| 3 Yellow | NOC / helpdesk / AD OH / IEPG + **former green leftovers** (staff OH, education/newcomer/tools, hackathon results, …) | Expanded; registration omitted |
+
+#### Parallel layout (required)
+
+`BlocksLayout` currently lays out each `BlockView` as full column width:
+
+```text
+left = headerWidth + column * columnWidth
+right = left + columnWidth
+```
+
+Two overlapping green blocks would cover each other.
+
+**Fix:**
+
+- Assign each side meeting a **sub-column 0 or 1** by room (stable sort of the two room titles/slugs from `_data.rooms`).
+- For `sidemeeting` blocks:
+  - **Full width** when alone in that time range
+  - **Half width** when two overlap:
+    - `left = headerWidth + column*columnWidth + sub*half`
+    - `width = columnWidth / 2`
+
+Block chip title: truncated booking title (not “Mon Session II”).  
+Tap → existing `SessionsFragment` for that `block_id` (usually one session).
+
+**Relevant files:**
+
+- `app/src/main/java/org/ietf/ietfsched/ui/ScheduleFragment.java`
+- `app/src/main/java/org/ietf/ietfsched/ui/widget/BlocksLayout.java`
+- `app/src/main/java/org/ietf/ietfsched/ui/widget/BlockView.java`
+- `app/src/main/res/values/colors.xml` (`block_column_3` green)
+
+### 4. Sessions list — badge like BoF (not a title prefix)
+
+Side meetings are normal `sessions` rows (list, search/FTS, starred).
+
+**Labeling:** mirror the existing **BoF** treatment — a small badge on the list row and detail header — not a `SIDE - …` title prefix.
+
+Existing pattern:
+
+- DB: `SESSION_IS_BOF`
+- UI: `session_bof_label` in `list_item_session.xml` / `fragment_session_detail.xml`
+- String: `bof_label` (“BoF”)
+
+For side meetings, use the same approach:
+
+- Detect via session id prefix `side-…` **or** a small `SESSION_IS_SIDE_MEETING` flag (prefix is enough for v1; flag optional if badge wiring is cleaner)
+- Add a **Side** (or **SIDE**) badge next to / analogous to the BoF badge
+- Keep the session title as the booking title (areas can stay in subtitle/search text)
+
+**Relevant files:**
+
+- `app/src/main/java/org/ietf/ietfsched/ui/SessionsFragment.java`
+- `app/src/main/res/layout/list_item_session.xml`
+- `app/src/main/res/layout/fragment_session_detail.xml`
+- `app/src/main/res/values/strings.xml`
+- (optional) drawable similar to `bof_label_bg.xml`
+
+### 5. Session detail (side-meeting-aware)
+
+Reuse `SessionDetailFragment` with light branching when the session is a side meeting:
+
+| Tab | Behavior for side meetings |
+|-----|----------------------------|
+| Content | Show `description` + organizer; skip slides/drafts when empty |
+| Notes | **Grayed out** (visible but disabled / non-interactive) |
+| Agenda | **Grayed out** (same) |
+| Join | Open API `location` as an **external** URL (browser / apps that handle the link) — **not** in-app WebView, and **not** Meetecho constructed from a group acronym |
+
+**Relevant files:**
+
+- `app/src/main/java/org/ietf/ietfsched/ui/SessionDetailFragment.java`
+- `app/src/main/java/org/ietf/ietfsched/ui/SessionJoinTabManager.java`
+- `app/src/main/java/org/ietf/ietfsched/ui/SessionNotesTabManager.java`
+- `app/src/main/java/org/ietf/ietfsched/ui/SessionContentTabBuilder.java`
+
+### 6. Drop registration; relocate remaining green items → **yellow**
+
+**Omit registration entirely** — do not create a block/session for registration (or purge if already present). It is a long, low-value schedule chip attendees rarely need.
+
+For everything else that currently uses `BLOCK_TYPE_OFFICE_HOURS`, remap → `BLOCK_TYPE_NOC_HELPDESK` (**yellow**):
+
+- Staff office hours (non-AD; AD already yellow)
+- Education / newcomer / tools / chairs / forum / etc.
+- Hackathon results / presentations (today forced into green to avoid red overlap)
+
+Green is reserved for `sidemeeting`. Blue stays food/breaks/social only.
+
+**Trade-off:** yellow gets a bit busier (service/admin cluster), but dropping registration removes the worst long-running collision source, and blue stays visually clean for meals/breaks.
+
+---
+
+## Implementation outline
+
+Suggested order:
+
+1. **Parser + sync** — short-timeout fetch of `_data`, map bookings → ContentProvider ops, purge, meeting-number guard aligned with `MeetingDetector`, fail soft
+2. **Block type + column map** — `sidemeeting` → column 2; drop registration; relocate remaining `officehours` → **yellow** (`nocHelpdesk`)
+3. **Overlapping layout** — room-based half-width when two side meetings overlap; full-width when alone
+4. **List / detail UX** — Side badge (BoF-style); description; grayed Notes/Agenda; external Join URL
+5. **Docs + tests** — update overview/notes; add Espresso cases (green chips, badge, detail, external join)
+6. **Manual check** on device/emulator with live IETF 126 data before the meeting
+
+### Build / test reminder (this workstation)
+
+Android cmdline tools:
+
+```text
+C:\Users\yaron\Applications\android-cmdline-tools
+```
+
+Also see `BUILD_AND_TEST.md` and `REGRESSION_TEST_PLAN.md` for project-specific Gradle / Espresso flows.
+
+---
+
+## Decisions (resolved from review)
+
+1. **Registration** — **Drop** from schedule/sessions (do not import).
+2. **Where remaining former green items go** — **Yellow** (`nocHelpdesk`). Blue stays food/breaks/social.
+3. **Half-width policy** — Full-width when alone; half-width when two overlap.
+4. **Meeting-number mismatch** — Skip import if `_data` ≠ detected meeting.
+5. **Schema** — Session-id prefix `side-{id}` for v1 (optional explicit flag later if useful for the badge).
+6. **Sessions list labeling** — **BoF-style badge** (“Side” / “SIDE”), not a title prefix.
+7. **Informal API resilience** — Short timeout, no wait on failure, agenda sync unaffected.
+8. **Meeting association** — Same `MeetingDetector` previous/next/ongoing logic as agenda.
+9. **Notes / Agenda tabs** — Grayed out (not hidden).
+10. **Join** — External URL only.
+
+---
+
+## Out of scope (for this pass)
+
+- Editing / requesting side meetings in-app
+- Calendar `.ics` export from the app (site already offers ICS)
+- Fifth schedule column
+- Offline-first redesign beyond normal sync caching
+- Showing historical side meetings for past IETF numbers (API is current-meeting-oriented)
+
+---
+
+## Success criteria
+
+- Green column shows side meetings for the active IETF meeting, with correct local times and rooms.
+- Two overlapping side meetings are both visible/tappable (half-width by room); single ones use full green width.
+- Side meetings appear in Sessions + search with a Side badge; can be starred.
+- Detail shows description; Notes/Agenda grayed; Join opens the remote URL outside the app.
+- Registration does **not** appear in schedule or sessions.
+- Remaining former green agenda items still appear (in **yellow**), not dropped.
+- Sync remains resilient if `_data` is empty, unreachable, slow, or for another meeting number — without delaying agenda sync.
+
+---
+
+## Doc index update
+
+After implementation, also update:
+
+- `OVERVIEW.md` — feature list + API endpoints
+- `IMPLEMENTATION_NOTES.md` — technical section
+- `REGRESSION_TEST_PLAN.md` — new Espresso scenarios
+
+(`OVERVIEW.md` still links to `CHANGES_LOG.md`, which is missing; optional cleanup when touching docs.)


### PR DESCRIPTION
## Summary
- Soft-fetch informal side-meeting data from `https://sidemeetings.ietf.org/_data` (4s/6s timeouts) after agenda sync; skip on failure or meeting-number mismatch so agenda never stalls.
- Put side meetings in the green Schedule column (half-width when two rooms overlap), with a green Side badge in Sessions and detail UX: description in Agenda, Content/Notes grayed, Join opens the remote URL.
- Drop registration; move former green leftovers to yellow. Schedule chip opens session detail directly.
- As-built design + device soft-fail smoke tests: `dev-docs/SIDE_MEETINGS_PLAN.md`.

The side-meetings `/_data` endpoint is still an **informal** API (not an official IETF contract). Sync treats it as best-effort and must never block or break agenda updates.

Note: **this is for the upcoming meeting, next week!**