### PR TITLE
Avoid application chooser on in-app session navigation (#40)

### DIFF
--- a/app/src/main/java/org/ietf/ietfsched/ui/DashboardFragment.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/DashboardFragment.java
@@ -20,6 +20,7 @@ package org.ietf.ietfsched.ui;
 import org.ietf.ietfsched.R;
 import org.ietf.ietfsched.provider.ScheduleContract;
 import org.ietf.ietfsched.ui.phone.ScheduleActivity;
+import org.ietf.ietfsched.ui.phone.SessionsActivity;
 import org.ietf.ietfsched.util.UIUtils;
 
 import android.content.Intent;
@@ -66,8 +67,11 @@ public class DashboardFragment extends Fragment {
 					return;
 					}
 				fireTrackerEvent("Sessions");
-				// Launch all sessions list directly (skip tracks screen)
-				final Intent intent = new Intent(Intent.ACTION_VIEW, ScheduleContract.Sessions.CONTENT_URI);
+				// Launch all sessions list directly (skip tracks screen).
+				// Explicit component avoids chooser with apps that over-match content:// VIEW (#40).
+				final Intent intent = new Intent(Intent.ACTION_VIEW,
+						ScheduleContract.Sessions.CONTENT_URI,
+						getActivity(), SessionsActivity.class);
 				intent.putExtra(Intent.EXTRA_TITLE, getString(R.string.title_sessions));
 				startActivity(intent);
 			}

--- a/app/src/main/java/org/ietf/ietfsched/ui/ScheduleFragment.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/ScheduleFragment.java
@@ -18,6 +18,8 @@ package org.ietf.ietfsched.ui;
 
 import org.ietf.ietfsched.R;
 import org.ietf.ietfsched.provider.ScheduleContract;
+import org.ietf.ietfsched.ui.phone.SessionDetailActivity;
+import org.ietf.ietfsched.ui.phone.SessionsActivity;
 import org.ietf.ietfsched.ui.widget.BlockView;
 import org.ietf.ietfsched.ui.widget.BlocksLayout;
 import org.ietf.ietfsched.ui.widget.ObservableScrollView;
@@ -526,12 +528,15 @@ public class ScheduleFragment extends Fragment implements
             final String blockId = ((BlockView) view).getBlockId();
             final Intent intent;
             // Side meetings are 1:1 with a session (same id) — skip the redundant list step.
+            // Explicit components avoid chooser with apps that over-match content:// VIEW (#40).
             if (ParserUtils.isSideMeetingSessionId(blockId)) {
                 final Uri sessionUri = ScheduleContract.Sessions.buildSessionUri(blockId);
-                intent = new Intent(Intent.ACTION_VIEW, sessionUri);
+                intent = new Intent(Intent.ACTION_VIEW, sessionUri,
+                        getActivity(), SessionDetailActivity.class);
             } else {
                 final Uri sessionsUri = ScheduleContract.Blocks.buildSessionsUri(blockId);
-                intent = new Intent(Intent.ACTION_VIEW, sessionsUri);
+                intent = new Intent(Intent.ACTION_VIEW, sessionsUri,
+                        getActivity(), SessionsActivity.class);
                 intent.putExtra(SessionsFragment.EXTRA_SCHEDULE_TIME_STRING,
                         ((BlockView) view).getBlockTimeString());
             }

--- a/app/src/main/java/org/ietf/ietfsched/ui/SessionsFragment.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/SessionsFragment.java
@@ -17,6 +17,7 @@ package org.ietf.ietfsched.ui;
 
 import org.ietf.ietfsched.R;
 import org.ietf.ietfsched.provider.ScheduleContract;
+import org.ietf.ietfsched.ui.phone.SessionDetailActivity;
 import org.ietf.ietfsched.util.ActivityHelper;
 import org.ietf.ietfsched.util.NotifyingAsyncQueryHandler;
 import org.ietf.ietfsched.util.ParserUtils;
@@ -232,7 +233,9 @@ public class SessionsFragment extends ListFragment implements NotifyingAsyncQuer
         }
 
         final Uri sessionUri = ScheduleContract.Sessions.buildSessionUri(sessionId);
-        final Intent intent = new Intent(Intent.ACTION_VIEW, sessionUri);
+        // Explicit component avoids chooser with apps that over-match content:// VIEW (#40).
+        final Intent intent = new Intent(Intent.ACTION_VIEW, sessionUri,
+                getActivity(), SessionDetailActivity.class);
         ((BaseActivity) getActivity()).openActivityOrFragment(intent);
 
         getListView().setItemChecked(position, true);

--- a/dev-docs/IMPLEMENTATION_NOTES.md
+++ b/dev-docs/IMPLEMENTATION_NOTES.md
@@ -634,6 +634,18 @@ protected void onCreate(Bundle savedInstanceState) {
 
 ---
 
+## Known issues / debug notes
+
+### #40 — Pebble vs IETF app chooser (not Join tab)
+
+**Observed:** Android “Open with Pebble or IETF app” when navigating to a session.
+
+**Root cause:** Implicit `ACTION_VIEW` on `content://org.ietf.ietfsched/sessions/...` from `SessionsFragment` / `ScheduleFragment` / home Sessions. Android also matched Pebble (`coredevices.coreapp`) via an over-broad `content://` VIEW filter.
+
+**Fix (on `ys-40`):** Explicit `SessionDetailActivity` / `SessionsActivity` components for those navigations. Firefox chooser on Agenda `https://` links is separate and unchanged.
+
+---
+
 ## References
 
 ### IETF Resources


### PR DESCRIPTION
## Summary
- Fix #40: in-app session/list navigation used implicit `ACTION_VIEW` on `content://org.ietf.ietfsched/...`, which also matched Pebble and showed an Open with chooser.
- Target `SessionDetailActivity` / `SessionsActivity` explicitly from Sessions list, Schedule blocks, and the home Sessions button.