### PR TITLE
Replace Now Playing with meeting Welcome/countdown/See you (#41)

### DIFF
--- a/app/src/androidTest/java/org/ietf/ietfsched/HomeScreenTest.java
+++ b/app/src/androidTest/java/org/ietf/ietfsched/HomeScreenTest.java
@@ -44,7 +44,7 @@ public class HomeScreenTest extends BaseTest {
         onView(withId(R.id.home_btn_starred))
                 .check(ViewAssertions.matches(isDisplayed()));
         
-        // Verify "Now Playing" section is visible at bottom
+        // Verify meeting status strip is visible at bottom
         onView(withId(R.id.fragment_now_playing))
                 .check(ViewAssertions.matches(isDisplayed()));
     }

--- a/app/src/main/java/org/ietf/ietfsched/io/MeetingDetector.java
+++ b/app/src/main/java/org/ietf/ietfsched/io/MeetingDetector.java
@@ -27,6 +27,7 @@ public class MeetingDetector {
     private static final long CACHE_JITTER_MAX = 5 * 60 * 1000; // 5 minutes randomization
     
     private static MeetingMetadata sCachedMeeting = null;
+    private static MeetingMetadata sCachedNextUpcoming = null;
     private static long sCacheTimestamp = 0;
     
     private final RemoteExecutor remoteExecutor;
@@ -34,6 +35,14 @@ public class MeetingDetector {
     
     public MeetingDetector(RemoteExecutor executor) {
         this.remoteExecutor = executor;
+    }
+
+    /**
+     * Nearest upcoming IETF meeting from the last detection (may be null).
+     * Not gated on agenda availability — used for the home "See you at …" bar.
+     */
+    public MeetingMetadata getCachedNextUpcomingMeeting() {
+        return sCachedNextUpcoming;
     }
     
     /**
@@ -68,15 +77,35 @@ public class MeetingDetector {
         
         // Find current or next meeting
         MeetingMetadata selectedMeeting = selectMeeting(meetings, now);
+        sCachedNextUpcoming = findNearestUpcoming(meetings, now);
         
         if (selectedMeeting != null) {
             sCachedMeeting = selectedMeeting;
             sCacheTimestamp = now;
             if (DEBUG) Log.d(TAG, "Selected meeting: IETF " + selectedMeeting.number + 
                 " (" + selectedMeeting.city + "), agenda=" + selectedMeeting.agendaAvailable);
+            if (DEBUG && sCachedNextUpcoming != null) {
+                Log.d(TAG, "Next upcoming: IETF " + sCachedNextUpcoming.number +
+                        " (" + sCachedNextUpcoming.city + ")");
+            }
         }
         
         return selectedMeeting;
+    }
+
+    /**
+     * Nearest meeting with start time strictly after {@code now} (agenda not required).
+     */
+    private static MeetingMetadata findNearestUpcoming(List<MeetingMetadata> meetings, long now) {
+        MeetingMetadata upcoming = null;
+        for (MeetingMetadata meeting : meetings) {
+            if (meeting.startMillis > now) {
+                if (upcoming == null || meeting.startMillis < upcoming.startMillis) {
+                    upcoming = meeting;
+                }
+            }
+        }
+        return upcoming;
     }
     
     /**

--- a/app/src/main/java/org/ietf/ietfsched/service/SyncService.java
+++ b/app/src/main/java/org/ietf/ietfsched/service/SyncService.java
@@ -117,6 +117,7 @@ public class SyncService extends IntentService {
 		
 		// Save meeting info for UI to use
 		MeetingPreferences.saveCurrentMeeting(context, meeting);
+		MeetingPreferences.saveNextMeeting(context, detector.getCachedNextUpcomingMeeting());
 		
 		// Update UIUtils with meeting timezone and dates
 		UIUtils.setConferenceTimeZone(meeting.timezone);

--- a/app/src/main/java/org/ietf/ietfsched/service/SyncService.java
+++ b/app/src/main/java/org/ietf/ietfsched/service/SyncService.java
@@ -117,7 +117,11 @@ public class SyncService extends IntentService {
 		
 		// Save meeting info for UI to use
 		MeetingPreferences.saveCurrentMeeting(context, meeting);
-		MeetingPreferences.saveNextMeeting(context, detector.getCachedNextUpcomingMeeting());
+		// Only persist next when detection computed one; never clear a known next on cache miss.
+		MeetingMetadata nextUpcoming = detector.getCachedNextUpcomingMeeting();
+		if (nextUpcoming != null) {
+			MeetingPreferences.saveNextMeeting(context, nextUpcoming);
+		}
 		
 		// Update UIUtils with meeting timezone and dates
 		UIUtils.setConferenceTimeZone(meeting.timezone);

--- a/app/src/main/java/org/ietf/ietfsched/ui/HomeActivity.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/HomeActivity.java
@@ -19,6 +19,7 @@ package org.ietf.ietfsched.ui;
 import org.ietf.ietfsched.R;
 import org.ietf.ietfsched.service.SyncService;
 import org.ietf.ietfsched.util.DetachableResultReceiver;
+import org.ietf.ietfsched.util.MeetingPreferences;
 
 import android.app.Activity;
 import android.app.BackgroundServiceStartNotAllowedException;
@@ -55,6 +56,9 @@ public class HomeActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Restore meeting dates/city for the home status bar before first draw.
+        MeetingPreferences.applySavedMeetingToUiUtils(this);
 
         setContentView(R.layout.activity_home);
         getActivityHelper().setupActionBar(null, 0);
@@ -164,6 +168,16 @@ public class HomeActivity extends BaseActivity {
 		return mSyncStatusUpdaterFragment != null ? mSyncStatusUpdaterFragment.mSyncing : false;
 		}
 
+    void refreshWhatsOnBar() {
+        Fragment f = getSupportFragmentManager().findFragmentById(R.id.fragment_now_playing);
+        if (f == null) {
+            f = getSupportFragmentManager().findFragmentById(R.id.fragment_whats_on);
+        }
+        if (f instanceof WhatsOnFragment) {
+            ((WhatsOnFragment) f).refreshStatus();
+        }
+    }
+
     /**
      * A non-UI fragment, retained across configuration changes, that updates its activity's UI
      * when sync status changes.
@@ -204,6 +218,7 @@ public class HomeActivity extends BaseActivity {
                     Toast.makeText(activity, "Schedule updated", Toast.LENGTH_SHORT).show();
                     // Reset manual refresh flag
                     activity.mIsManualRefresh = false;
+                    activity.refreshWhatsOnBar();
                     break;
                 }
                 case SyncService.STATUS_ERROR: {

--- a/app/src/main/java/org/ietf/ietfsched/ui/WhatsOnFragment.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/WhatsOnFragment.java
@@ -17,122 +17,173 @@
 package org.ietf.ietfsched.ui;
 
 import org.ietf.ietfsched.R;
+import org.ietf.ietfsched.util.MeetingPreferences;
 import org.ietf.ietfsched.util.UIUtils;
 
 import android.app.Activity;
 import android.os.Bundle;
 import android.os.Handler;
 import androidx.fragment.app.Fragment;
-import android.text.format.DateUtils;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
 /**
- * A fragment used in {@link HomeActivity} that shows either a countdown, 'now playing' link to
- * current sessions, or 'thank you' text, at different times (before/during/after the conference).
- * It also shows a 'Realtime Search' button on phones, as a replacement for the
- * fragment that is visible on tablets on the home screen.
+ * Home strip that shows meeting-aware status:
+ * before → countdown to IETF-N in City;
+ * during → Welcome to IETF-N in City;
+ * after → See you at the next meeting (when known).
  */
 public class WhatsOnFragment extends Fragment {
 
-    private final ThreadLocal<Handler> mMessageHandler = ThreadLocal.withInitial(() -> new Handler());
+    private final Handler mHandler = new Handler();
 
-    private TextView mCountdownTextView;
+    private TextView mStatusTextView;
     private ViewGroup mRootView;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
             Bundle savedInstanceState) {
-        mRootView = (ViewGroup) inflater.inflate(R.layout.fragment_whats_on, container);
+        mRootView = (ViewGroup) inflater.inflate(R.layout.fragment_whats_on, container, false);
         refresh();
         return mRootView;
     }
 
     @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
+    public void onResume() {
+        super.onResume();
+        refresh();
+    }
+
+    /** Re-read prefs and update the status strip (e.g. after sync). */
+    public void refreshStatus() {
+        if (mRootView != null) {
+            refresh();
+        }
     }
 
     @Override
     public void onDetach() {
         super.onDetach();
-        mMessageHandler.get().removeCallbacks(mCountdownRunnable);
+        mHandler.removeCallbacks(mDayRolloverRunnable);
     }
 
     private void refresh() {
-        mMessageHandler.get().removeCallbacks(mCountdownRunnable);
+        mHandler.removeCallbacks(mDayRolloverRunnable);
         mRootView.removeAllViews();
+        mStatusTextView = null;
 
-        final long currentTimeMillis = UIUtils.getCurrentTime(getActivity());
-
-        // Show Loading... and load the view corresponding to the current state
-        if (currentTimeMillis < UIUtils.getConferenceStart()) {
-            setupBefore();
-        } else if (currentTimeMillis > UIUtils.getConferenceEnd()) {
-            setupAfter();
-        } else {
-            setupDuring();
+        Activity activity = getActivity();
+        if (activity == null) {
+            return;
         }
-    }
-	
 
-    private void setupBefore() {
-        // Before conference, show countdown.
-        mCountdownTextView = (TextView) getActivity().getLayoutInflater().inflate(
-                R.layout.whats_on_countdown, mRootView, false);
-        mRootView.addView(mCountdownTextView);
-        mMessageHandler.get().post(mCountdownRunnable);
-    }
+        // Prefer prefs (includes city); fall back to UIUtils dates from sync this process.
+        long start = MeetingPreferences.getCurrentMeetingStart(activity);
+        long end = MeetingPreferences.getCurrentMeetingEnd(activity);
+        if (start == 0 || end == 0) {
+            start = UIUtils.getConferenceStart();
+            end = UIUtils.getConferenceEnd();
+        }
+        if (start == 0 || end == 0 || end == Long.MAX_VALUE) {
+            return; // Nothing useful to show yet
+        }
 
-    private void setupAfter() {
-        // After conference, show canned text.
-        getActivity().getLayoutInflater().inflate(
-                R.layout.whats_on_thank_you, mRootView, true);
-    }
+        final long now = System.currentTimeMillis();
+        final int number = MeetingPreferences.getCurrentMeetingNumber(activity);
+        final String city = MeetingPreferences.getCurrentMeetingCity(activity);
 
-    private void setupDuring() {
-        // Conference in progress, show "Now Playing" link.
-        View view = getActivity().getLayoutInflater().inflate(
-                R.layout.whats_on_now_playing, mRootView, false);
-        view.setOnClickListener(new View.OnClickListener() {
-				public void onClick(View view) {
+        mStatusTextView = (TextView) activity.getLayoutInflater().inflate(
+                R.layout.whats_on_status, mRootView, false);
+        mRootView.addView(mStatusTextView);
+
+        if (now < start) {
+            updateCountdownText(number, city, start, now);
+            scheduleNextDayRefresh();
+        } else if (now > end) {
+            int nextNumber = MeetingPreferences.getNextMeetingNumber(activity);
+            String nextCity = MeetingPreferences.getNextMeetingCity(activity);
+            // Avoid "See you at IETF-N" when prefs still point at the meeting that just ended.
+            if (nextNumber > 0 && nextNumber != number && !TextUtils.isEmpty(nextCity)) {
+                mStatusTextView.setText(getString(
+                        R.string.whats_on_see_you, nextNumber, nextCity));
+            } else if (nextNumber > 0 && nextNumber != number) {
+                mStatusTextView.setText(getString(
+                        R.string.whats_on_see_you_no_city, nextNumber));
+            } else {
+                mStatusTextView.setText(R.string.whats_on_thank_you_title);
             }
-        });
-        mRootView.addView(view);
+        } else {
+            if (number > 0 && !TextUtils.isEmpty(city)) {
+                mStatusTextView.setText(getString(
+                        R.string.whats_on_welcome, number, city));
+            } else if (number > 0) {
+                mStatusTextView.setText(getString(
+                        R.string.whats_on_welcome_no_city, number));
+            } else {
+                mStatusTextView.setText(R.string.whats_on_welcome_generic);
+            }
+        }
     }
 
     /**
-     * Event that updates countdown timer. Posts itself again to {@link #mMessageHandler} to
-     * continue updating time.
+     * Full calendar days from local today until the meeting's local start date.
      */
-    private Runnable mCountdownRunnable = new Runnable() {
+    private static int fullLocalDaysUntil(long startMillis, long nowMillis) {
+        ZoneId local = ZoneId.systemDefault();
+        LocalDate today = Instant.ofEpochMilli(nowMillis).atZone(local).toLocalDate();
+        LocalDate startDay = Instant.ofEpochMilli(startMillis).atZone(local).toLocalDate();
+        long days = ChronoUnit.DAYS.between(today, startDay);
+        return (int) Math.max(0, days);
+    }
+
+    private void updateCountdownText(int number, String city, long startMillis, long now) {
+        if (mStatusTextView == null) {
+            return;
+        }
+        if (now >= startMillis) {
+            mHandler.post(new Runnable() {
+                public void run() {
+                    refresh();
+                }
+            });
+            return;
+        }
+
+        final int days = fullLocalDaysUntil(startMillis, now);
+        if (number > 0 && !TextUtils.isEmpty(city)) {
+            mStatusTextView.setText(getResources().getQuantityString(
+                    R.plurals.whats_on_countdown_to_meeting, days, days, number, city));
+        } else if (number > 0) {
+            mStatusTextView.setText(getResources().getQuantityString(
+                    R.plurals.whats_on_countdown_to_meeting_no_city, days, days, number));
+        } else {
+            mStatusTextView.setText(getResources().getQuantityString(
+                    R.plurals.whats_on_countdown_title, days, days, ""));
+        }
+    }
+
+    /** Recompute when the local calendar day rolls over (full-day countdown). */
+    private void scheduleNextDayRefresh() {
+        ZoneId local = ZoneId.systemDefault();
+        ZonedDateTime nextMidnight = ZonedDateTime.now(local).toLocalDate()
+                .plusDays(1).atStartOfDay(local);
+        long delayMs = Math.max(1000L,
+                nextMidnight.toInstant().toEpochMilli() - System.currentTimeMillis());
+        mHandler.postDelayed(mDayRolloverRunnable, delayMs);
+    }
+
+    private final Runnable mDayRolloverRunnable = new Runnable() {
         public void run() {
-            int remainingSec = (int) Math.max(0,
-                    (UIUtils.getConferenceStart() - System.currentTimeMillis()) / 1000);
-            final boolean conferenceStarted = remainingSec == 0;
-
-            if (conferenceStarted) {
-                // Conference started while in countdown mode, switch modes and
-                // bail on future countdown updates.
-                mMessageHandler.get().postDelayed(new Runnable() {
-                    public void run() {
-                        refresh();
-                    }
-                }, 100);
-                return;
-            }
-
-            final int secs = remainingSec % 86400;
-            final int days = remainingSec / 86400;
-            final String str = getResources().getQuantityString(
-                    R.plurals.whats_on_countdown_title, days, days,
-                    DateUtils.formatElapsedTime(secs));
-            mCountdownTextView.setText(str);
-
-            // Repost ourselves to keep updating countdown
-            mMessageHandler.get().postDelayed(mCountdownRunnable, 1000);
+            refresh();
         }
     };
 }

--- a/app/src/main/java/org/ietf/ietfsched/ui/WhatsOnFragment.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/WhatsOnFragment.java
@@ -40,7 +40,7 @@ import java.time.temporal.ChronoUnit;
  * Home strip that shows meeting-aware status:
  * before → countdown to IETF-N in City;
  * during → Welcome to IETF-N in City;
- * after → See you at the next meeting (when known).
+ * after → See you at IETF-N in City when next meeting is known (else hide).
  */
 public class WhatsOnFragment extends Fragment {
 
@@ -119,7 +119,9 @@ public class WhatsOnFragment extends Fragment {
                 mStatusTextView.setText(getString(
                         R.string.whats_on_see_you_no_city, nextNumber));
             } else {
-                mStatusTextView.setText(R.string.whats_on_thank_you_title);
+                // No automated next meeting yet — skip the old generic thank-you.
+                mRootView.removeView(mStatusTextView);
+                mStatusTextView = null;
             }
         } else {
             if (number > 0 && !TextUtils.isEmpty(city)) {

--- a/app/src/main/java/org/ietf/ietfsched/util/MeetingPreferences.java
+++ b/app/src/main/java/org/ietf/ietfsched/util/MeetingPreferences.java
@@ -11,11 +11,14 @@ import java.util.TimeZone;
 public class MeetingPreferences {
     private static final String PREFS_NAME = "meeting_prefs";
     private static final String KEY_MEETING_NUMBER = "meeting_number";
+    private static final String KEY_MEETING_CITY = "meeting_city";
     private static final String KEY_MEETING_TIMEZONE = "meeting_timezone";
     private static final String KEY_MEETING_START = "meeting_start";
     private static final String KEY_MEETING_END = "meeting_end";
     private static final String KEY_AGENDA_URL = "agenda_url";
-    
+    private static final String KEY_NEXT_MEETING_NUMBER = "next_meeting_number";
+    private static final String KEY_NEXT_MEETING_CITY = "next_meeting_city";
+
     /**
      * Saves the current meeting metadata to preferences.
      */
@@ -23,13 +26,47 @@ public class MeetingPreferences {
         SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         prefs.edit()
             .putInt(KEY_MEETING_NUMBER, meeting.number)
+            .putString(KEY_MEETING_CITY, meeting.city != null ? meeting.city : "")
             .putString(KEY_MEETING_TIMEZONE, meeting.timezone.getID())
             .putLong(KEY_MEETING_START, meeting.startMillis)
             .putLong(KEY_MEETING_END, meeting.endMillis)
             .putString(KEY_AGENDA_URL, meeting.agendaUrl)
             .apply();
     }
-    
+
+    /**
+     * Saves the nearest upcoming meeting (may be null to clear).
+     * Used for the post-meeting "See you at …" bar.
+     */
+    public static void saveNextMeeting(Context context, MeetingMetadata next) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = prefs.edit();
+        if (next == null) {
+            editor.remove(KEY_NEXT_MEETING_NUMBER).remove(KEY_NEXT_MEETING_CITY);
+        } else {
+            editor.putInt(KEY_NEXT_MEETING_NUMBER, next.number)
+                    .putString(KEY_NEXT_MEETING_CITY, next.city != null ? next.city : "");
+        }
+        editor.apply();
+    }
+
+    /**
+     * Applies saved meeting timezone/dates into {@link UIUtils} for cold start.
+     * @return true if prefs contained a meeting with valid dates
+     */
+    public static boolean applySavedMeetingToUiUtils(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        long start = prefs.getLong(KEY_MEETING_START, 0);
+        long end = prefs.getLong(KEY_MEETING_END, 0);
+        if (start == 0 || end == 0) {
+            return false;
+        }
+        String tzId = prefs.getString(KEY_MEETING_TIMEZONE, "UTC");
+        UIUtils.setConferenceTimeZone(TimeZone.getTimeZone(tzId));
+        UIUtils.setConferenceDates(start, end);
+        return true;
+    }
+
     /**
      * Retrieves the saved meeting number, or 0 if not set.
      */
@@ -37,7 +74,35 @@ public class MeetingPreferences {
         SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         return prefs.getInt(KEY_MEETING_NUMBER, 0);
     }
-    
+
+    public static String getCurrentMeetingCity(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        return prefs.getString(KEY_MEETING_CITY, "");
+    }
+
+    public static long getCurrentMeetingStart(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        return prefs.getLong(KEY_MEETING_START, 0);
+    }
+
+    public static long getCurrentMeetingEnd(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        return prefs.getLong(KEY_MEETING_END, 0);
+    }
+
+    /**
+     * Next upcoming meeting number, or 0 if unknown.
+     */
+    public static int getNextMeetingNumber(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        return prefs.getInt(KEY_NEXT_MEETING_NUMBER, 0);
+    }
+
+    public static String getNextMeetingCity(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        return prefs.getString(KEY_NEXT_MEETING_CITY, "");
+    }
+
     /**
      * Retrieves the saved meeting timezone, or UTC if not set.
      */

--- a/app/src/main/res/layout/whats_on_status.xml
+++ b/app/src/main/res/layout/whats_on_status.xml
@@ -1,0 +1,30 @@
+<!--
+  Copyright 2011 Google Inc.
+  Copyright 2026
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/whats_on_status"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:paddingLeft="@dimen/whats_on_item_padding"
+    android:paddingRight="@dimen/whats_on_item_padding"
+    android:textSize="@dimen/text_size_small"
+    android:textStyle="bold"
+    android:textColor="@color/body_text_1"
+    android:maxLines="2"
+    android:ellipsize="end"
+    android:hyphenationFrequency="full"
+    android:breakStrategy="balanced" />

--- a/app/src/main/res/values-xlarge-v11/strings.xml
+++ b/app/src/main/res/values-xlarge-v11/strings.xml
@@ -14,10 +14,5 @@
   limitations under the License.
   -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <plurals name="whats_on_countdown_title">
-        <item quantity="zero"><xliff:g id="remaining_time">%2$s</xliff:g> until IETF 99</item>
-        <item quantity="one"><xliff:g id="number_of_days">%1$s</xliff:g> day, <xliff:g id="remaining_time">%2$s</xliff:g> until IETF 99</item>
-        <item quantity="other"><xliff:g id="number_of_days">%1$s</xliff:g> days, <xliff:g id="remaining_time">%2$s</xliff:g> until IETF 99</item>
-    </plurals>
-
+    <!-- Use default phone strings (no hardcoded IETF 99). -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,14 +107,28 @@
     <string name="share_template">Checking out \'<xliff:g id="title">%1$s</xliff:g>\' at <xliff:g id="hashtags">%2$s</xliff:g> <xliff:g id="url">%3$s</xliff:g></string>
 
     <plurals name="whats_on_countdown_title">
-        <item quantity="zero"><xliff:g id="remaining_time">%2$s</xliff:g>\nuntil IETF meeting</item>
-        <item quantity="one"><xliff:g id="number_of_days">%1$s</xliff:g> day, <xliff:g id="remaining_time">%2$s</xliff:g>\nuntil IETF meeting</item>
-        <item quantity="other"><xliff:g id="number_of_days">%1$s</xliff:g> days, <xliff:g id="remaining_time">%2$s</xliff:g>\nuntil IETF meeting</item>
+        <item quantity="one"><xliff:g id="number_of_days">%1$d</xliff:g> day until IETF meeting</item>
+        <item quantity="other"><xliff:g id="number_of_days">%1$d</xliff:g> days until IETF meeting</item>
     </plurals>
+
+    <plurals name="whats_on_countdown_to_meeting">
+        <item quantity="one"><xliff:g id="days">%1$d</xliff:g> day to IETF-<xliff:g id="number">%2$d</xliff:g> in <xliff:g id="city">%3$s</xliff:g></item>
+        <item quantity="other"><xliff:g id="days">%1$d</xliff:g> days to IETF-<xliff:g id="number">%2$d</xliff:g> in <xliff:g id="city">%3$s</xliff:g></item>
+    </plurals>
+    <plurals name="whats_on_countdown_to_meeting_no_city">
+        <item quantity="one"><xliff:g id="days">%1$d</xliff:g> day to IETF-<xliff:g id="number">%2$d</xliff:g></item>
+        <item quantity="other"><xliff:g id="days">%1$d</xliff:g> days to IETF-<xliff:g id="number">%2$d</xliff:g></item>
+    </plurals>
+
+    <string name="whats_on_welcome">Welcome to IETF-<xliff:g id="number">%1$d</xliff:g> in <xliff:g id="city">%2$s</xliff:g>!</string>
+    <string name="whats_on_welcome_no_city">Welcome to IETF-<xliff:g id="number">%1$d</xliff:g>!</string>
+    <string name="whats_on_welcome_generic">Welcome to the IETF meeting!</string>
+    <string name="whats_on_see_you">See you at IETF-<xliff:g id="number">%1$d</xliff:g> in <xliff:g id="city">%2$s</xliff:g>!</string>
+    <string name="whats_on_see_you_no_city">See you at IETF-<xliff:g id="number">%1$d</xliff:g>!</string>
 
     <string name="whats_on_stream_title">Realtime\nStream</string>
     <string name="whats_on_now_playing_title">Now Playing</string>
-	<string name="whats_on_thank_you_title">See you at the next IETF meeting</string>
+	<string name="whats_on_thank_you_title">See you at the next IETF meeting!</string>
     <string name="permission_write">Modify IETF schedule data</string>
     <string name="toast_now_not_visible">Press this button during an IETF meeting to show the current time.</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -143,8 +143,7 @@
     <!-- What's On section in Home activity -->
 
     <style name="WhatsOnItemBase">
-        <item name="android:layout_width">0dp</item>
-        <item name="android:layout_weight">1</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">fill_parent</item>
         <item name="android:textSize">@dimen/text_size_small</item>
         <item name="android:textStyle">bold</item>
@@ -153,6 +152,7 @@
         <item name="android:paddingLeft">@dimen/whats_on_item_padding</item>
         <item name="android:paddingRight">@dimen/whats_on_item_padding</item>
         <item name="android:gravity">center</item>
+        <item name="android:ellipsize">end</item>
     </style>
 
     <style name="WhatsOnStaticItem" parent="@style/WhatsOnItemBase">

--- a/dev-docs/REGRESSION_TEST_PLAN.md
+++ b/dev-docs/REGRESSION_TEST_PLAN.md
@@ -21,7 +21,7 @@ This document outlines the regression test plan for the IETF Schedule app using 
 **Tests**:
 - [x] Home screen displays correctly (`testHomeScreenDisplays`)
   - Verify all main buttons are visible: Schedule, Sessions, Starred
-  - Verify "Now Playing" section is visible at bottom
+  - Verify meeting status strip is visible at bottom (Welcome / countdown / See you)
 - [x] "Schedule" button navigates to schedule (`testScheduleButton`)
   - Click Schedule button
   - Verify ScheduleActivity is displayed


### PR DESCRIPTION
## Summary
- Fix #41: replace the non-functional Now Playing control with an automated home status strip.
- **During:** `Welcome to IETF-N in City!`
- **Before:** full calendar days in the **device** timezone, e.g. `5 days to IETF-N in City`
- **After:** `See you at IETF-N in City!` when the next meeting is known (else generic thank-you)
- Persist current city + next meeting number/city in `MeetingPreferences` (refreshed on sync); layout fits long city names (2 lines, ellipsize).