### PR TITLE
Show Agenda unavailable instead of perpetual loading (#37)

### DIFF
--- a/app/src/main/java/org/ietf/ietfsched/ui/SessionAgendaTabManager.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/SessionAgendaTabManager.java
@@ -161,7 +161,9 @@ public class SessionAgendaTabManager {
         if (agendaUrl == null || agendaUrl.isEmpty()) {
             initializeWebView();
             if (mWebView != null) {
-                showLoadingMessage("Agenda is being downloaded. Please check back in a moment or use the Refresh button.");
+                // No URL from Datatracker — not a transient download; show final state (#37).
+                mCurrentUrl = "";
+                showStatusMessage(mFragment.getString(R.string.agenda_unavailable));
             }
             return;
         }
@@ -288,23 +290,22 @@ public class SessionAgendaTabManager {
                         }
                     }
                 } else {
-                    // Empty content - try loading directly
-                    Log.w(TAG, "fetchAndLoadAgenda: Empty content, loading URL directly");
+                    // Empty content - agenda URL exists but body is empty
+                    Log.w(TAG, "fetchAndLoadAgenda: Empty content");
                     if (mFragment.getActivity() != null) {
                         mFragment.getActivity().runOnUiThread(() -> {
                             if (mWebView != null) {
-                                mWebView.loadUrl(agendaUrl);
+                                showStatusMessage(mFragment.getString(R.string.agenda_unavailable));
                             }
                         });
                     }
                 }
             } catch (Exception e) {
                 Log.e(TAG, "Failed to fetch agenda", e);
-                // Fallback to direct URL load
                 if (mFragment.getActivity() != null) {
                     mFragment.getActivity().runOnUiThread(() -> {
                         if (mWebView != null) {
-                            mWebView.loadUrl(agendaUrl);
+                            showErrorMessage();
                         }
                     });
                 }
@@ -420,9 +421,9 @@ public class SessionAgendaTabManager {
     }
 
     /**
-     * Show loading or status message.
+     * Show status or placeholder message in the Agenda WebView.
      */
-    private void showLoadingMessage(String message) {
+    private void showStatusMessage(String message) {
         if (mWebView == null) {
             return;
         }
@@ -453,8 +454,7 @@ public class SessionAgendaTabManager {
             return;
         }
         
-        String errorMessage = "Unable to load agenda. Please check your internet connection and try again.";
-        showLoadingMessage(errorMessage);
+        showStatusMessage(mFragment.getString(R.string.agenda_load_error));
     }
     
     /**

--- a/app/src/main/java/org/ietf/ietfsched/ui/SessionDetailFragment.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/SessionDetailFragment.java
@@ -876,7 +876,7 @@ public class SessionDetailFragment extends Fragment implements
             return;
         }
         String agendaUrl = cursor.getString(SessionsQuery.SESSION_URL);
-        // Always call updateAgendaTab - it will show loading message if URL is null/empty
+        // Empty URL → Agenda unavailable (not a perpetual loading placeholder).
         mAgendaTabManager.updateAgendaTab(agendaUrl != null ? agendaUrl : "");
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,8 @@
     <string name="session_notes">Notes</string>
     <string name="session_links">Links</string>
     <string name="session_agenda">Agenda</string>
+    <string name="agenda_unavailable">Agenda unavailable</string>
+    <string name="agenda_load_error">Unable to load agenda. Please check your internet connection and try again.</string>
     <string name="session_join">Join</string>
     <string name="empty_join">No join information available</string>
     <string name="join_error_message">Unable to load Meetecho Lite. Please check your internet connection and try again.\n\nNote: Meetecho Lite is only available during the IETF meeting.</string>


### PR DESCRIPTION
﻿## Summary
- When a session has no agenda URL (or the fetched agenda body is empty), show **Agenda unavailable** instead of the perpetual "Agenda is being downloaded..." placeholder.
- Fetch failures show a clear connection error string rather than falling back to a blank URL load.
- Notes unavailable is out of scope for this PR (agendas only).

Fixes #37
