### PR TITLE
Agenda: markdown render + unavailable state (#45, #37)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     // Required for OnBackPressedCallback to work correctly with swipe gestures
     implementation 'androidx.activity:activity:1.12.3'
     implementation "org.commonmark:commonmark:0.21.0"
+    implementation "org.commonmark:commonmark-ext-autolink:0.21.0"
     // GeckoView for better WebView compatibility
     implementation "org.mozilla.geckoview:geckoview:145.0.20251118022223"
     

--- a/app/src/main/java/org/ietf/ietfsched/io/RemoteExecutor.java
+++ b/app/src/main/java/org/ietf/ietfsched/io/RemoteExecutor.java
@@ -36,6 +36,17 @@ public class RemoteExecutor {
 
 	private static final String TAG = "RemoteExecutor HTTP";
 
+	/** Body and Content-Type from an HTTP GET (Content-Type may be null). */
+	public static final class HttpGetResult {
+		public final String body;
+		public final String contentType;
+
+		public HttpGetResult(String body, String contentType) {
+			this.body = body != null ? body : "";
+			this.contentType = contentType;
+		}
+	}
+
     public RemoteExecutor() { }
 
 
@@ -74,6 +85,13 @@ public class RemoteExecutor {
 
 	// Get a String object from a remote server.
 	public String executeGet(String urlString) throws Exception {
+		return executeGetWithContentType(urlString).body;
+	}
+
+	/**
+	 * GET text body and Content-Type (e.g. text/markdown from Datatracker materials).
+	 */
+	public HttpGetResult executeGetWithContentType(String urlString) throws Exception {
 		HttpsURLConnection urlConnection = null;
 		try {
 			URL url = new URI(urlString).toURL();
@@ -81,8 +99,9 @@ public class RemoteExecutor {
 
 			int status = urlConnection.getResponseCode();
 			Log.d(TAG, "executeGet: status=" + status + " for " + urlString);
-			
+
 			if (status == HttpsURLConnection.HTTP_OK) {
+				String contentType = urlConnection.getContentType();
 				StringBuilder result = new StringBuilder();
 				BufferedReader reader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
 				String line;
@@ -95,14 +114,9 @@ public class RemoteExecutor {
 						break;
 					}
 				}
-				if (urlConnection != null) {
-					urlConnection.disconnect();
-				}
-				return result.toString();
+				return new HttpGetResult(result.toString(), contentType);
 			} else {
-				// Log non-200 status codes
 				Log.w(TAG, "executeGet: Non-200 status " + status + " for " + urlString);
-				// For 503 or other errors, return null to indicate failure
 				if (status == 503 || status >= 500) {
 					throw new Exception("Server error: HTTP " + status);
 				}
@@ -112,7 +126,7 @@ public class RemoteExecutor {
 				urlConnection.disconnect();
 			}
 		}
-		return new String();
+		return new HttpGetResult("", null);
 	}
 
 	// Get a JSON object from a remote server.

--- a/app/src/main/java/org/ietf/ietfsched/ui/BaseGeckoViewTabManager.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/BaseGeckoViewTabManager.java
@@ -21,9 +21,8 @@ import android.view.View;
 import android.view.ViewGroup;
 import androidx.fragment.app.Fragment;
 import org.ietf.ietfsched.util.GeckoViewHelper;
+import org.ietf.ietfsched.util.MarkdownHtml;
 import org.mozilla.geckoview.GeckoView;
-import org.commonmark.parser.Parser;
-import org.commonmark.renderer.html.HtmlRenderer;
 
 /**
  * Base class for GeckoView tab managers with common functionality for loading messages and error handling.
@@ -168,11 +167,7 @@ public abstract class BaseGeckoViewTabManager {
      * @param markdownText The markdown text to load
      */
     private void loadMarkdownAsDataUri(String markdownText) {
-        // Convert markdown to HTML
-        Parser parser = Parser.builder().build();
-        HtmlRenderer renderer = HtmlRenderer.builder().build();
-        org.commonmark.node.Node document = parser.parse(markdownText);
-        String htmlContent = renderer.render(document);
+        String htmlContent = MarkdownHtml.render(markdownText);
         
         // Wrap HTML with basic styling
         String styledHtml = "<!DOCTYPE html>" +

--- a/app/src/main/java/org/ietf/ietfsched/ui/SessionAgendaTabManager.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/SessionAgendaTabManager.java
@@ -325,16 +325,7 @@ public class SessionAgendaTabManager {
     }
 
     private String wrapPlainTextAgendaHtml(String content) {
-        String contentWithLinks = convertUrlsToLinks(content);
-        String tempContent = contentWithLinks.replaceAll(
-                "<a href=\"([^\"]+)\">([^<]+)</a>",
-                "___LINK_START___$1___LINK_MID___$2___LINK_END___");
-        String escapedContent = tempContent.replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;");
-        escapedContent = escapedContent.replace("___LINK_START___", "<a href=\"")
-                .replace("___LINK_MID___", "\">")
-                .replace("___LINK_END___", "</a>");
+        String escapedContent = escapePlainTextPreservingLinks(convertUrlsToLinks(content));
 
         String css =
                 "body { " +
@@ -420,6 +411,22 @@ public class SessionAgendaTabManager {
 
         return result.toString();
     }
+
+    /**
+     * Escape plain text for HTML while preserving &lt;a href&gt; tags from
+     * {@link #convertUrlsToLinks}.
+     */
+    private String escapePlainTextPreservingLinks(String contentWithLinks) {
+        String temp = contentWithLinks.replaceAll(
+                "<a href=\"([^\"]+)\">([^<]+)</a>",
+                "___LINK_START___$1___LINK_MID___$2___LINK_END___");
+        String escaped = temp.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
+        return escaped.replace("___LINK_START___", "<a href=\"")
+                .replace("___LINK_MID___", "\">")
+                .replace("___LINK_END___", "</a>");
+    }
     
     /**
      * Check if content is HTML or plain text.
@@ -462,14 +469,15 @@ public class SessionAgendaTabManager {
     
     /**
      * Show plain text (e.g. side-meeting description) in the Agenda WebView.
-     * Newlines become &lt;br&gt;; HTML in the source is escaped.
+     * Newlines become &lt;br&gt;; http(s) URLs become links; other HTML is escaped.
      */
     public void showPlainText(String text) {
         initializeWebView();
         if (mWebView == null) {
             return;
         }
-        String body = text == null ? "" : android.text.TextUtils.htmlEncode(text).replace("\n", "<br>");
+        String raw = text == null ? "" : text;
+        String body = escapePlainTextPreservingLinks(convertUrlsToLinks(raw)).replace("\n", "<br>");
         String html = "<!DOCTYPE html>" +
             "<html><head>" +
             "<meta name='viewport' content='width=device-width, initial-scale=1'>" +
@@ -482,6 +490,7 @@ public class SessionAgendaTabManager {
             "  color: #222; " +
             "  white-space: normal; " +
             "}" +
+            "a { color: #0066cc; text-decoration: underline; }" +
             "</style>" +
             "</head><body>" +
             body +

--- a/app/src/main/java/org/ietf/ietfsched/ui/SessionAgendaTabManager.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/SessionAgendaTabManager.java
@@ -29,8 +29,10 @@ import android.content.Intent;
 import androidx.fragment.app.Fragment;
 import org.ietf.ietfsched.R;
 import org.ietf.ietfsched.io.RemoteExecutor;
+import org.ietf.ietfsched.util.MarkdownHtml;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Locale;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
@@ -197,108 +199,183 @@ public class SessionAgendaTabManager {
     }
     
     /**
-     * Fetch agenda page and wrap with CSS if plain text, otherwise load directly.
+     * Fetch agenda page; use Content-Type when available (Datatracker materials).
+     * text/html → load URL; text/markdown → commonmark; text/plain → escaped pre-wrap.
      */
     private void fetchAndLoadAgenda(String agendaUrl) {
         Log.d(TAG, "fetchAndLoadAgenda: Fetching " + agendaUrl);
-        
-        // Fetch content in background thread
+
         new Thread(() -> {
             try {
                 RemoteExecutor executor = new RemoteExecutor();
-                String content = executor.executeGet(agendaUrl);
-                
-                Log.d(TAG, "fetchAndLoadAgenda: Fetch completed, content length=" + 
-                    (content != null ? content.length() : 0));
-                
-                if (content != null && !content.isEmpty()) {
-                    // Check if content is HTML or plain text
-                    boolean isHTML = isHtmlContent(content);
-                    
-                    if (isHTML) {
-                        // Already HTML - load directly without modification
-                        Log.d(TAG, "fetchAndLoadAgenda: Content is HTML, loading directly");
-                        if (mFragment.getActivity() != null) {
-                            mFragment.getActivity().runOnUiThread(() -> {
-                                if (mWebView != null) {
-                                    mWebView.loadUrl(agendaUrl);
-                                }
-                            });
-                        }
-                    } else {
-                        // Plain text - wrap with CSS, preserve newlines, and convert URLs to links
-                        Log.d(TAG, "fetchAndLoadAgenda: Content is plain text, wrapping with CSS");
-                        
-                        String escapedContent = escapePlainTextPreservingLinks(
-                                convertUrlsToLinks(content));
+                RemoteExecutor.HttpGetResult result = executor.executeGetWithContentType(agendaUrl);
+                String content = result.body;
+                String mime = primaryMimeType(result.contentType);
 
-                        String css = 
-                            "body { " +
-                            "  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; " +
-                            "  font-size: 16px; " +
-                            "  line-height: 1.6; " +
-                            "  color: #333; " +
-                            "  padding: 16px; " +
-                            "  white-space: pre-wrap; " +
-                            "  word-wrap: break-word; " +
-                            "} " +
-                            "a { " +
-                            "  color: #0066cc; " +
-                            "  text-decoration: underline; " +
-                            "}";
-                        
-                        String wrappedHtml = "<!DOCTYPE html>" +
-                            "<html><head>" +
-                            "<meta name='viewport' content='width=device-width, initial-scale=1'>" +
-                            "<style>" + css + "</style>" +
-                            "</head><body>" +
-                            escapedContent +
-                            "</body></html>";
-                        
-                        // Load as data URI on main thread
-                        if (mFragment.getActivity() != null) {
-                            mFragment.getActivity().runOnUiThread(() -> {
-                                if (mWebView != null) {
-                                    try {
-                                        byte[] htmlBytes = wrappedHtml.getBytes("UTF-8");
-                                        String base64Html = android.util.Base64.encodeToString(htmlBytes, android.util.Base64.NO_WRAP);
-                                        String dataUri = "data:text/html;charset=utf-8;base64," + base64Html;
-                                        mWebView.loadUrl(dataUri);
-                                        Log.d(TAG, "fetchAndLoadAgenda: Loaded plain text as data URI");
-                                    } catch (UnsupportedEncodingException e) {
-                                        Log.e(TAG, "Failed to encode HTML", e);
-                                        // Fallback to direct URL load
-                                        mWebView.loadUrl(agendaUrl);
-                                    }
-                                }
-                            });
-                        }
-                    }
-                } else {
-                    // Empty content - try loading directly
+                Log.d(TAG, "fetchAndLoadAgenda: length=" +
+                        (content != null ? content.length() : 0) + " contentType=" + result.contentType);
+
+                if (content == null || content.isEmpty()) {
                     Log.w(TAG, "fetchAndLoadAgenda: Empty content, loading URL directly");
-                    if (mFragment.getActivity() != null) {
-                        mFragment.getActivity().runOnUiThread(() -> {
-                            if (mWebView != null) {
-                                mWebView.loadUrl(agendaUrl);
-                            }
-                        });
-                    }
-                }
-            } catch (Exception e) {
-                Log.e(TAG, "Failed to fetch agenda", e);
-                // Fallback to direct URL load
-                if (mFragment.getActivity() != null) {
-                    mFragment.getActivity().runOnUiThread(() -> {
+                    runOnUi(() -> {
                         if (mWebView != null) {
                             mWebView.loadUrl(agendaUrl);
                         }
                     });
+                    return;
                 }
+
+                AgendaFormat format = classifyAgenda(mime, content);
+                Log.d(TAG, "fetchAndLoadAgenda: format=" + format);
+
+                if (format == AgendaFormat.HTML) {
+                    runOnUi(() -> {
+                        if (mWebView != null) {
+                            mWebView.loadUrl(agendaUrl);
+                        }
+                    });
+                    return;
+                }
+
+                final String wrappedHtml;
+                if (format == AgendaFormat.MARKDOWN) {
+                    // Links only via commonmark AutolinkExtension — do not run convertUrlsToLinks.
+                    wrappedHtml = wrapMarkdownAgendaHtml(content);
+                } else {
+                    wrappedHtml = wrapPlainTextAgendaHtml(content);
+                }
+
+                runOnUi(() -> {
+                    if (mWebView != null) {
+                        loadHtmlDataUri(wrappedHtml, agendaUrl);
+                    }
+                });
+            } catch (Exception e) {
+                Log.e(TAG, "Failed to fetch agenda", e);
+                runOnUi(() -> {
+                    if (mWebView != null) {
+                        mWebView.loadUrl(agendaUrl);
+                    }
+                });
             }
         }).start();
     }
-    
+
+    private enum AgendaFormat {
+        HTML,
+        MARKDOWN,
+        PLAIN
+    }
+
+    private static String primaryMimeType(String contentType) {
+        if (contentType == null || contentType.isEmpty()) {
+            return null;
+        }
+        int semi = contentType.indexOf(';');
+        String primary = semi >= 0 ? contentType.substring(0, semi) : contentType;
+        return primary.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private AgendaFormat classifyAgenda(String mime, String content) {
+        if (mime != null) {
+            if (mime.equals("text/html") || mime.equals("application/xhtml+xml")) {
+                return AgendaFormat.HTML;
+            }
+            if (mime.equals("text/markdown") || mime.equals("text/x-markdown")) {
+                return AgendaFormat.MARKDOWN;
+            }
+            if (mime.equals("text/plain")) {
+                return AgendaFormat.PLAIN;
+            }
+        }
+        // No useful Content-Type: keep HTML sniff; otherwise treat as markdown (#45).
+        if (isHtmlContent(content)) {
+            return AgendaFormat.HTML;
+        }
+        return AgendaFormat.MARKDOWN;
+    }
+
+    private String wrapMarkdownAgendaHtml(String markdown) {
+        String htmlContent = MarkdownHtml.render(markdown);
+        String css =
+                "body { " +
+                "  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; " +
+                "  font-size: 16px; " +
+                "  line-height: 1.6; " +
+                "  color: #333; " +
+                "  padding: 16px; " +
+                "  word-wrap: break-word; " +
+                "} " +
+                "a { color: #0066cc; text-decoration: underline; } " +
+                "h1, h2, h3, h4 { margin-top: 1.2em; margin-bottom: 0.4em; } " +
+                "ul, ol { padding-left: 1.4em; } " +
+                "li { margin-bottom: 0.35em; } " +
+                "code, pre { font-family: ui-monospace, Consolas, monospace; font-size: 0.92em; } " +
+                "pre { overflow-x: auto; background: #f5f5f5; padding: 8px; }";
+        return "<!DOCTYPE html>" +
+                "<html><head>" +
+                "<meta name='viewport' content='width=device-width, initial-scale=1'>" +
+                "<style>" + css + "</style>" +
+                "</head><body>" +
+                htmlContent +
+                "</body></html>";
+    }
+
+    private String wrapPlainTextAgendaHtml(String content) {
+        String contentWithLinks = convertUrlsToLinks(content);
+        String tempContent = contentWithLinks.replaceAll(
+                "<a href=\"([^\"]+)\">([^<]+)</a>",
+                "___LINK_START___$1___LINK_MID___$2___LINK_END___");
+        String escapedContent = tempContent.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
+        escapedContent = escapedContent.replace("___LINK_START___", "<a href=\"")
+                .replace("___LINK_MID___", "\">")
+                .replace("___LINK_END___", "</a>");
+
+        String css =
+                "body { " +
+                "  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; " +
+                "  font-size: 16px; " +
+                "  line-height: 1.6; " +
+                "  color: #333; " +
+                "  padding: 16px; " +
+                "  white-space: pre-wrap; " +
+                "  word-wrap: break-word; " +
+                "} " +
+                "a { " +
+                "  color: #0066cc; " +
+                "  text-decoration: underline; " +
+                "}";
+
+        return "<!DOCTYPE html>" +
+                "<html><head>" +
+                "<meta name='viewport' content='width=device-width, initial-scale=1'>" +
+                "<style>" + css + "</style>" +
+                "</head><body>" +
+                escapedContent +
+                "</body></html>";
+    }
+
+    private void loadHtmlDataUri(String wrappedHtml, String fallbackUrl) {
+        try {
+            byte[] htmlBytes = wrappedHtml.getBytes("UTF-8");
+            String base64Html = android.util.Base64.encodeToString(htmlBytes, android.util.Base64.NO_WRAP);
+            String dataUri = "data:text/html;charset=utf-8;base64," + base64Html;
+            mWebView.loadUrl(dataUri);
+            Log.d(TAG, "fetchAndLoadAgenda: Loaded agenda as data URI");
+        } catch (UnsupportedEncodingException e) {
+            Log.e(TAG, "Failed to encode HTML", e);
+            mWebView.loadUrl(fallbackUrl);
+        }
+    }
+
+    private void runOnUi(Runnable action) {
+        if (mFragment.getActivity() != null) {
+            mFragment.getActivity().runOnUiThread(action);
+        }
+    }
+
     /**
      * Inject CSS into the loaded page (for data URIs).
      */
@@ -313,7 +390,12 @@ public class SessionAgendaTabManager {
     }
     
     /**
+     * Convert bare https URLs to anchors. Used only for {@link AgendaFormat#PLAIN}
+     * agendas — markdown uses {@link MarkdownHtml} / AutolinkExtension instead.
+     */
+    /**
      * Convert plain text http(s) URLs to HTML anchor tags.
+     * Used only for {@link AgendaFormat#PLAIN} — markdown uses AutolinkExtension.
      */
     private String convertUrlsToLinks(String text) {
         if (text == null || text.isEmpty()) {
@@ -334,22 +416,6 @@ public class SessionAgendaTabManager {
         matcher.appendTail(result);
 
         return result.toString();
-    }
-
-    /**
-     * Escape plain text for HTML while preserving &lt;a href&gt; tags from
-     * {@link #convertUrlsToLinks}.
-     */
-    private String escapePlainTextPreservingLinks(String contentWithLinks) {
-        String temp = contentWithLinks.replaceAll(
-                "<a href=\"([^\"]+)\">([^<]+)</a>",
-                "___LINK_START___$1___LINK_MID___$2___LINK_END___");
-        String escaped = temp.replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;");
-        return escaped.replace("___LINK_START___", "<a href=\"")
-                .replace("___LINK_MID___", "\">")
-                .replace("___LINK_END___", "</a>");
     }
     
     /**
@@ -393,15 +459,14 @@ public class SessionAgendaTabManager {
     
     /**
      * Show plain text (e.g. side-meeting description) in the Agenda WebView.
-     * http(s) URLs become tappable links; newlines become &lt;br&gt;; other HTML is escaped.
+     * Newlines become &lt;br&gt;; HTML in the source is escaped.
      */
     public void showPlainText(String text) {
         initializeWebView();
         if (mWebView == null) {
             return;
         }
-        String raw = text == null ? "" : text;
-        String body = escapePlainTextPreservingLinks(convertUrlsToLinks(raw)).replace("\n", "<br>");
+        String body = text == null ? "" : android.text.TextUtils.htmlEncode(text).replace("\n", "<br>");
         String html = "<!DOCTYPE html>" +
             "<html><head>" +
             "<meta name='viewport' content='width=device-width, initial-scale=1'>" +
@@ -414,7 +479,6 @@ public class SessionAgendaTabManager {
             "  color: #222; " +
             "  white-space: normal; " +
             "}" +
-            "a { color: #0066cc; text-decoration: underline; }" +
             "</style>" +
             "</head><body>" +
             body +

--- a/app/src/main/java/org/ietf/ietfsched/ui/SessionAgendaTabManager.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/SessionAgendaTabManager.java
@@ -163,7 +163,9 @@ public class SessionAgendaTabManager {
         if (agendaUrl == null || agendaUrl.isEmpty()) {
             initializeWebView();
             if (mWebView != null) {
-                showLoadingMessage("Agenda is being downloaded. Please check back in a moment or use the Refresh button.");
+                // No URL from Datatracker — not a transient download; show final state (#37).
+                mCurrentUrl = "";
+                showStatusMessage(mFragment.getString(R.string.agenda_unavailable));
             }
             return;
         }
@@ -216,10 +218,11 @@ public class SessionAgendaTabManager {
                         (content != null ? content.length() : 0) + " contentType=" + result.contentType);
 
                 if (content == null || content.isEmpty()) {
-                    Log.w(TAG, "fetchAndLoadAgenda: Empty content, loading URL directly");
+                    // Empty body — not a transient download (#37).
+                    Log.w(TAG, "fetchAndLoadAgenda: Empty content");
                     runOnUi(() -> {
                         if (mWebView != null) {
-                            mWebView.loadUrl(agendaUrl);
+                            showStatusMessage(mFragment.getString(R.string.agenda_unavailable));
                         }
                     });
                     return;
@@ -254,7 +257,7 @@ public class SessionAgendaTabManager {
                 Log.e(TAG, "Failed to fetch agenda", e);
                 runOnUi(() -> {
                     if (mWebView != null) {
-                        mWebView.loadUrl(agendaUrl);
+                        showErrorMessage();
                     }
                 });
             }
@@ -488,9 +491,9 @@ public class SessionAgendaTabManager {
     }
 
     /**
-     * Show loading or status message.
+     * Show status or placeholder message in the Agenda WebView.
      */
-    private void showLoadingMessage(String message) {
+    private void showStatusMessage(String message) {
         if (mWebView == null) {
             return;
         }
@@ -521,8 +524,7 @@ public class SessionAgendaTabManager {
             return;
         }
         
-        String errorMessage = "Unable to load agenda. Please check your internet connection and try again.";
-        showLoadingMessage(errorMessage);
+        showStatusMessage(mFragment.getString(R.string.agenda_load_error));
     }
     
     /**

--- a/app/src/main/java/org/ietf/ietfsched/ui/SessionDetailFragment.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/SessionDetailFragment.java
@@ -937,7 +937,7 @@ public class SessionDetailFragment extends Fragment implements
             return;
         }
         String agendaUrl = cursor.getString(SessionsQuery.SESSION_URL);
-        // Always call updateAgendaTab - it will show loading message if URL is null/empty
+        // Empty URL → Agenda unavailable (not a perpetual loading placeholder).
         mAgendaTabManager.updateAgendaTab(agendaUrl != null ? agendaUrl : "");
     }
 

--- a/app/src/main/java/org/ietf/ietfsched/ui/WellNoteFragment.java
+++ b/app/src/main/java/org/ietf/ietfsched/ui/WellNoteFragment.java
@@ -25,10 +25,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import org.mozilla.geckoview.GeckoView;
 
-import org.commonmark.parser.Parser;
-import org.commonmark.renderer.html.HtmlRenderer;
 import org.ietf.ietfsched.service.SyncService;
 import org.ietf.ietfsched.util.GeckoViewHelper;
+import org.ietf.ietfsched.util.MarkdownHtml;
 
 
 /**
@@ -112,11 +111,8 @@ public class WellNoteFragment extends Fragment {
             }
         }
         
-        // Convert markdown to HTML
-        Parser parser = Parser.builder().build();
-        HtmlRenderer renderer = HtmlRenderer.builder().build();
-        org.commonmark.node.Node document = parser.parse(markdownText);
-        String htmlContent = renderer.render(document);
+        // Convert markdown to HTML (bare URLs become links via AutolinkExtension)
+        String htmlContent = MarkdownHtml.render(markdownText);
         
         // Wrap HTML with basic styling
         String styledHtml = "<!DOCTYPE html>" +

--- a/app/src/main/java/org/ietf/ietfsched/util/MarkdownHtml.java
+++ b/app/src/main/java/org/ietf/ietfsched/util/MarkdownHtml.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ietf.ietfsched.util;
+
+import org.commonmark.Extension;
+import org.commonmark.ext.autolink.AutolinkExtension;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Markdown → HTML via commonmark, with bare URL/email autolinking.
+ */
+public final class MarkdownHtml {
+    private static final List<Extension> EXTENSIONS =
+            Collections.singletonList(AutolinkExtension.create());
+
+    private MarkdownHtml() {
+    }
+
+    public static String render(String markdown) {
+        Parser parser = Parser.builder().extensions(EXTENSIONS).build();
+        HtmlRenderer renderer = HtmlRenderer.builder().build();
+        return renderer.render(parser.parse(markdown != null ? markdown : ""));
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,8 @@
     <string name="session_notes">Notes</string>
     <string name="session_links">Links</string>
     <string name="session_agenda">Agenda</string>
+    <string name="agenda_unavailable">Agenda unavailable</string>
+    <string name="agenda_load_error">Unable to load agenda. Please check your internet connection and try again.</string>
     <string name="session_join">Join</string>
     <string name="empty_join">No join information available</string>
     <string name="join_error_message">Unable to load Meetecho Lite. Please check your internet connection and try again.\n\nNote: Meetecho Lite is only available during the IETF meeting.</string>


### PR DESCRIPTION
## Summary
- Combines former PRs #48 (#45 markdown) and #50 (#37 unavailable) into one change so they do not fight over `SessionAgendaTabManager`.
- Datatracker agendas: `Content-Type` drives HTML / markdown (commonmark) / plain rendering; plain text keeps http(s) linkify (#42), including side-meeting `showPlainText`.
- Empty agenda URL or empty fetch body shows **Agenda unavailable** instead of perpetual downloading; fetch errors use a clear error string.

Fixes #45
Fixes #37