### PR TITLE
Migrate side meetings to official public API (#52)

### DIFF
--- a/app/src/main/java/org/ietf/ietfsched/io/SideMeetingImporter.java
+++ b/app/src/main/java/org/ietf/ietfsched/io/SideMeetingImporter.java
@@ -46,11 +46,56 @@ public class SideMeetingImporter {
     private static final String TAG = "SideMeetingImporter";
     public static final String SIDE_MEETINGS_URL =
             "https://sidemeetings.ietf.org/api/public/schedule";
+    public static final String SIDE_MEETINGS_LIST_URL =
+            "https://sidemeetings.ietf.org/api/public/meetings";
     /** Short timeouts so a broken side-meetings API never stalls agenda sync. */
     public static final int CONNECT_TIMEOUT_MS = 4000;
     public static final int READ_TIMEOUT_MS = 6000;
 
     private SideMeetingImporter() {}
+
+    /**
+     * Resolve the schedule URL for {@code meetingNumber}. Prefers
+     * {@code /api/public/schedule?meetingId=} when the meetings list is available,
+     * otherwise falls back to the default (active) schedule endpoint.
+     */
+    public static String resolveScheduleUrl(RemoteExecutor executor, int meetingNumber) {
+        if (executor == null || meetingNumber <= 0) {
+            return SIDE_MEETINGS_URL;
+        }
+        try {
+            String body = executor.executeGet(SIDE_MEETINGS_LIST_URL);
+            if (body == null || body.trim().isEmpty()) {
+                return SIDE_MEETINGS_URL;
+            }
+            String trimmed = body.trim();
+            if (trimmed.charAt(0) != '[') {
+                Log.w(TAG, "Unexpected meetings list payload");
+                return SIDE_MEETINGS_URL;
+            }
+            JSONArray meetings = new JSONArray(trimmed);
+            for (int i = 0; i < meetings.length(); i++) {
+                JSONObject m = meetings.optJSONObject(i);
+                if (m == null) continue;
+                String numStr = firstNonEmpty(m.optString("num", ""), m.optString("meetingNumber", ""));
+                try {
+                    if (Integer.parseInt(numStr.trim()) != meetingNumber) continue;
+                } catch (NumberFormatException e) {
+                    continue;
+                }
+                String id = m.optString("id", "").trim();
+                if (!id.isEmpty()) {
+                    String url = SIDE_MEETINGS_URL + "?meetingId=" + id;
+                    Log.d(TAG, "Using schedule URL for IETF " + meetingNumber + ": " + url);
+                    return url;
+                }
+            }
+            Log.i(TAG, "No public meeting id for IETF " + meetingNumber + "; using default schedule");
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to resolve side-meeting schedule URL: " + e.getMessage());
+        }
+        return SIDE_MEETINGS_URL;
+    }
 
     /**
      * Build insert ops for side meetings. Returns empty list on any problem.

--- a/app/src/main/java/org/ietf/ietfsched/io/SideMeetingImporter.java
+++ b/app/src/main/java/org/ietf/ietfsched/io/SideMeetingImporter.java
@@ -38,13 +38,15 @@ import java.util.Comparator;
 import java.util.HashMap;
 
 /**
- * Imports informal side-meeting bookings from https://sidemeetings.ietf.org/_data
- * into the same blocks/rooms/sessions tables used by the agenda sync.
+ * Imports side-meeting bookings from the official public schedule API
+ * ({@code https://sidemeetings.ietf.org/api/public/schedule}) into the same
+ * blocks/rooms/sessions tables used by the agenda sync.
  */
 public class SideMeetingImporter {
     private static final String TAG = "SideMeetingImporter";
-    public static final String SIDE_MEETINGS_URL = "https://sidemeetings.ietf.org/_data";
-    /** Short timeouts so a broken informal API never stalls agenda sync. */
+    public static final String SIDE_MEETINGS_URL =
+            "https://sidemeetings.ietf.org/api/public/schedule";
+    /** Short timeouts so a broken side-meetings API never stalls agenda sync. */
     public static final int CONNECT_TIMEOUT_MS = 4000;
     public static final int READ_TIMEOUT_MS = 6000;
 
@@ -67,7 +69,10 @@ public class SideMeetingImporter {
                 Log.w(TAG, "No meeting object in side meetings data");
                 return batch;
             }
-            String numberStr = meeting.optString("meetingNumber", "");
+            // Public API: meeting.num; legacy informal feed used meetingNumber.
+            String numberStr = firstNonEmpty(
+                    meeting.optString("num", ""),
+                    meeting.optString("meetingNumber", ""));
             int sideMeetingNumber;
             try {
                 sideMeetingNumber = Integer.parseInt(numberStr.trim());
@@ -81,7 +86,7 @@ public class SideMeetingImporter {
                 return batch;
             }
 
-            HashMap<Long, Integer> roomSubColumn = assignRoomSubColumns(sideData.optJSONArray("rooms"));
+            HashMap<String, Integer> roomSubColumn = assignRoomSubColumns(sideData.optJSONArray("rooms"));
             JSONArray bookings = sideData.optJSONArray("bookings");
             if (bookings == null || bookings.length() == 0) {
                 Log.i(TAG, "No side meeting bookings");
@@ -104,8 +109,8 @@ public class SideMeetingImporter {
         return batch;
     }
 
-    private static HashMap<Long, Integer> assignRoomSubColumns(JSONArray rooms) {
-        HashMap<Long, Integer> map = new HashMap<>();
+    private static HashMap<String, Integer> assignRoomSubColumns(JSONArray rooms) {
+        HashMap<String, Integer> map = new HashMap<>();
         if (rooms == null || rooms.length() == 0) {
             return map;
         }
@@ -117,14 +122,20 @@ public class SideMeetingImporter {
         Collections.sort(sorted, new Comparator<JSONObject>() {
             @Override
             public int compare(JSONObject a, JSONObject b) {
-                String ta = a.optString("title", a.optString("slug", ""));
-                String tb = b.optString("title", b.optString("slug", ""));
+                String ta = firstNonEmpty(
+                        a.optString("name", ""),
+                        a.optString("title", ""),
+                        a.optString("slug", ""));
+                String tb = firstNonEmpty(
+                        b.optString("name", ""),
+                        b.optString("title", ""),
+                        b.optString("slug", ""));
                 return ta.compareToIgnoreCase(tb);
             }
         });
         for (int i = 0; i < sorted.size(); i++) {
-            long id = sorted.get(i).optLong("id", -1);
-            if (id >= 0) {
+            String id = sorted.get(i).optString("id", "").trim();
+            if (!id.isEmpty()) {
                 map.put(id, Math.min(i, 1)); // at most two parallel rooms
             }
         }
@@ -132,17 +143,22 @@ public class SideMeetingImporter {
     }
 
     private static ContentProviderOperation[] buildBookingOps(
-            JSONObject booking, HashMap<Long, Integer> roomSubColumn,
+            JSONObject booking, HashMap<String, Integer> roomSubColumn,
             long versionBuild, ContentResolver resolver) {
         try {
-            long bookingId = booking.optLong("id", -1);
-            if (bookingId < 0) return null;
+            // Public API uses UUID strings; legacy feed used numeric ids.
+            String bookingId = booking.optString("id", "").trim();
+            if (bookingId.isEmpty()) return null;
 
             String title = booking.optString("title", "").trim();
             if (title.isEmpty()) return null;
 
-            String startIso = booking.optString("start", "");
-            String endIso = booking.optString("end", "");
+            String startIso = firstNonEmpty(
+                    booking.optString("startsAt", ""),
+                    booking.optString("start", ""));
+            String endIso = firstNonEmpty(
+                    booking.optString("endsAt", ""),
+                    booking.optString("end", ""));
             long startMillis = parseIsoMillis(startIso);
             long endMillis = parseIsoMillis(endIso);
             if (startMillis <= 0 || endMillis <= startMillis) {
@@ -151,7 +167,7 @@ public class SideMeetingImporter {
             }
 
             String roomName = booking.optString("roomName", "").trim();
-            long roomApiId = booking.optLong("roomId", -1);
+            String roomApiId = booking.optString("roomId", "").trim();
             int sub = roomSubColumn.containsKey(roomApiId) ? roomSubColumn.get(roomApiId) : 0;
             String blockType = ParserUtils.BLOCK_TYPE_SIDE_MEETING + sub;
 
@@ -161,7 +177,9 @@ public class SideMeetingImporter {
             String blockId = sessionId;
             String roomId = roomName.isEmpty() ? null : Rooms.generateRoomId(roomName);
 
-            String joinUrl = booking.optString("location", "").trim();
+            String joinUrl = firstNonEmpty(
+                    booking.optString("videoLinkUrl", ""),
+                    booking.optString("location", "")).trim();
             String description = booking.optString("description", "").trim();
             String organizer = booking.optString("organizerName", "").trim();
             String organizerEmail = booking.optString("organizerEmail", "").trim();
@@ -226,6 +244,16 @@ public class SideMeetingImporter {
             Log.w(TAG, "Skipping booking", e);
             return null;
         }
+    }
+
+    private static String firstNonEmpty(String... values) {
+        if (values == null) return "";
+        for (String v : values) {
+            if (v != null && !v.trim().isEmpty()) {
+                return v;
+            }
+        }
+        return "";
     }
 
     private static String joinAreas(JSONArray areas) {

--- a/app/src/main/java/org/ietf/ietfsched/service/SyncService.java
+++ b/app/src/main/java/org/ietf/ietfsched/service/SyncService.java
@@ -166,8 +166,9 @@ public class SyncService extends IntentService {
 			// Soft-fetch side meetings (short timeout); never fail the agenda sync on this.
 			JSONObject sideMeetings = null;
 			try {
+				String sideUrl = SideMeetingImporter.resolveScheduleUrl(mRemoteExecutor, meeting.number);
 				sideMeetings = mRemoteExecutor.executeJSONGet(
-						SideMeetingImporter.SIDE_MEETINGS_URL,
+						sideUrl,
 						SideMeetingImporter.CONNECT_TIMEOUT_MS,
 						SideMeetingImporter.READ_TIMEOUT_MS);
 				if (sideMeetings == null || sideMeetings.length() == 0) {

--- a/dev-docs/SIDE_MEETINGS_PLAN.md
+++ b/dev-docs/SIDE_MEETINGS_PLAN.md
@@ -113,9 +113,9 @@ TabHost setup can fire spurious changes; Join action is gated until `mTabHostRea
 ## Known limitations / non-goals
 
 - No in-app Join WebView / no blocking of Webex→Play Store redirects (explicitly declined).
-- No historical side meetings for other IETF numbers (`/_data` is current-meeting-oriented).
+- No historical side meetings for other IETF numbers (default schedule is the active meeting; optional `?meetingId=` later).
 - No ICS export, no request/edit flow.
-- No Espresso coverage yet (deferred while `/_data` is informal); no updates yet to `OVERVIEW.md` / `IMPLEMENTATION_NOTES.md`.
+- No Espresso coverage yet; no updates yet to `OVERVIEW.md` / `IMPLEMENTATION_NOTES.md`.
 - Windows ARM64: no Google Emulator package; device + scrcpy for UI work.
 
 ---
@@ -128,9 +128,9 @@ TabHost setup can fire spurious changes; Join action is gated until `mTabHostRea
 - [x] Agenda shows description; Content/Notes grayed; Join opens remote URL
 - [x] Schedule chip opens detail directly
 - [x] Registration omitted; former green items in yellow
-- [x] Soft-fail `/_data` without blocking agenda sync (device smoke tests below)
+- [x] Soft-fail public schedule without blocking agenda sync (device smoke tests below)
 - [ ] Dev-docs follow-up (`OVERVIEW`, `IMPLEMENTATION_NOTES`)
-- [ ] Espresso cases — **skipped for now** (informal `/_data` API; revisit when official)
+- [ ] Espresso cases — revisit with official API
 
 ---
 

--- a/dev-docs/SIDE_MEETINGS_PLAN.md
+++ b/dev-docs/SIDE_MEETINGS_PLAN.md
@@ -2,7 +2,7 @@
 
 Status: **Implemented** (IETF 126)  
 Branch: `ys-side-meetings`  
-Data: [https://sidemeetings.ietf.org/](https://sidemeetings.ietf.org/) · informal API [https://sidemeetings.ietf.org/_data](https://sidemeetings.ietf.org/_data)
+Data: [https://sidemeetings.ietf.org/](https://sidemeetings.ietf.org/) · public API [https://sidemeetings.ietf.org/api/public/schedule](https://sidemeetings.ietf.org/api/public/schedule) (docs: [/api/docs](https://sidemeetings.ietf.org/api/docs))
 
 Local tooling (this workstation):
 
@@ -26,8 +26,8 @@ Show IETF **side meetings** in **Sessions** and on the **Schedule** grid by **re
 
 | Plan item | Status | Notes |
 |-----------|--------|-------|
-| Soft-fetch `/_data` with short timeout | Done | 4s connect / 6s read; agenda sync continues on failure |
-| Meeting-number guard vs `MeetingDetector` | Done | Skip import if `_data` ≠ active meeting |
+| Soft-fetch public schedule with short timeout | Done | 4s connect / 6s read; agenda sync continues on failure |
+| Meeting-number guard vs `MeetingDetector` | Done | Skip import if `meeting.num` ≠ active meeting |
 | Same `UPDATED` purge stamp as agenda | Done | `SideMeetingImporter` ops merged into `LocalExecutor` batch |
 | Preserve stars | Done | Same `querySessionStarred` pattern |
 | `side-{id}` session/block ids | Done | Prefix detection; no schema migration |
@@ -59,8 +59,8 @@ Show IETF **side meetings** in **Sessions** and on the **Schedule** grid by **re
 
 ### Sync
 
-1. After agenda JSON fetch, soft-GET `https://sidemeetings.ietf.org/_data`.
-2. `SideMeetingImporter.buildOperations(...)` only if meeting numbers match.
+1. After agenda JSON fetch, soft-GET `https://sidemeetings.ietf.org/api/public/schedule`.
+2. `SideMeetingImporter.buildOperations(...)` only if `meeting.num` matches.
 3. Ops applied in the **same** batch / purge as agenda (`LocalExecutor.execute(agenda, number, sideData)`).
 
 **Key files:** `SyncService.java`, `RemoteExecutor.java` (timeouts), `SideMeetingImporter.java`, `LocalExecutor.java`.
@@ -77,7 +77,7 @@ Show IETF **side meetings** in **Sessions** and on the **Schedule** grid by **re
 | `location` | `SESSION_URL` (Join external link) |
 | `areas[]` | `SESSION_KEYWORDS` |
 
-Room sub-column: rooms from `_data` sorted by title → index 0/1 → block type suffix.
+Room sub-column: rooms from schedule API sorted by `name` → index 0/1 → block type suffix.
 
 ### Schedule UX
 
@@ -141,9 +141,9 @@ Run on Pixel 8a (`adb` + scrcpy). Method: temporary code change → `assembleDeb
 | Case | How forced | Expected log | Observed |
 |------|------------|--------------|----------|
 | Meeting-number mismatch | Pass `meetingNumber + 999` into `SideMeetingImporter.buildOperations` | `Skipping side meetings: data is for IETF 126 but app meeting is …` then `remote sync finished` | Pass |
-| Bad / empty `/_data` | Point `SIDE_MEETINGS_URL` at a non-existent path | `Side meetings fetch returned empty data` then `remote sync finished` | Pass |
-| Connect timeout | Point URL at `https://192.0.2.1/_data` (TEST-NET blackhole) | `Side meetings fetch failed (continuing without them): … after 4000ms` then `remote sync finished` | Pass (~4s connect timeout) |
-| Happy path (restore) | Real `https://sidemeetings.ietf.org/_data` | `Prepared N ops for M side bookings` then `remote sync finished` | Pass (`117` ops / `39` bookings for IETF 126) |
+| Bad / empty schedule | Point `SIDE_MEETINGS_URL` at a non-existent path | `Side meetings fetch returned empty data` then `remote sync finished` | Pass |
+| Connect timeout | Point URL at `https://192.0.2.1/api/public/schedule` (TEST-NET blackhole) | `Side meetings fetch failed (continuing without them): … after 4000ms` then `remote sync finished` | Pass (~4s connect timeout) |
+| Happy path (restore) | Real `https://sidemeetings.ietf.org/api/public/schedule` | `Prepared N ops for M side bookings` then `remote sync finished` | Pass |
 
 Also verified earlier by hand on device: green column / half-width overlap, Side badge, detail tabs (Agenda text, Content+Notes grayed, Join external), schedule chip → detail directly.
 


### PR DESCRIPTION
## Summary
- Migrate side-meeting sync from the dead informal `/_data` feed to the official public API (`/api/public/schedule`).
- Parse new field names/IDs: `meeting.num`, `startsAt`/`endsAt`, `videoLinkUrl`, UUID booking/room ids, `rooms[].name`.
- Resolve `?meetingId=` via `/api/public/meetings` so the schedule matches the app's current IETF meeting number (default schedule is only the API "active" meeting).
- Soft-fail behavior unchanged: side-meeting fetch never blocks agenda sync.

Fixes #52